### PR TITLE
Added an error message when you name class and file with names that don't match.

### DIFF
--- a/lib/goliath/application.rb
+++ b/lib/goliath/application.rb
@@ -45,7 +45,9 @@ module Goliath
     # @return [Nil]
     def self.run!
       file = File.basename(app_file, '.rb')
-      klass = begin Kernel.const_get(camel_case(file)) rescue NameError
+      klass = begin
+        Kernel.const_get(camel_case(file))
+      rescue NameError
         raise NameError, "Class #{camel_case(file)} not found."
       end
       api = klass.new


### PR DESCRIPTION
When making my first test, I received the following error message:

```
/Users/carlosbrando/.rvm/gems/ruby-1.9.2-p180/gems/goliath-0.9.0/lib/goliath/application.rb:49:in `run!': undefined method `new' for Goliath:Module (NoMethodError)
    from /Users/carlosbrando/.rvm/gems/ruby-1.9.2-p180/gems/goliath-0.9.0/lib/goliath/application.rb:87:in `block in <module:Goliath>'
```

Only after reviewing the code of your project that I realized that the class name and the file name should be equal. I took the liberty of adding an error message informing the user that it is necessary.
