### PR TITLE
Goliath with rack routes

### DIFF
--- a/lib/goliath/application.rb
+++ b/lib/goliath/application.rb
@@ -53,21 +53,7 @@ module Goliath
       api = klass.new
 
       runner = Goliath::Runner.new(ARGV, api)
-      runner.load_app do
-        klass.middlewares.each do |mw|
-          use(*(mw[0..1].compact), &mw[2])
-        end
-
-        # If you use map you can't use run as
-        # the rack builder will blowup.
-        if klass.maps.empty?
-          run api
-        else
-          klass.maps.each do |mp|
-            map(mp.first, &mp.last)
-          end
-        end
-      end
+      runner.load_app(klass)
 
       runner.load_plugins(klass.plugins)
       runner.run

--- a/lib/goliath/env.rb
+++ b/lib/goliath/env.rb
@@ -13,7 +13,6 @@ module Goliath
     # @return [Goliath::Env] The Goliath::Env object
     def initialize
       self[SERVER_SOFTWARE]   = SERVER
-      self[SERVER_NAME]       = LOCALHOST
       self[RACK_VERSION]      = RACK_VERSION_NUM
       self[RACK_ERRORS]       = STDERR
       self[RACK_MULTITHREAD]  = false


### PR DESCRIPTION
Hey guys,

So this is a pull request to fix a issue with goliath using rack routes.  Basically routes would only resolve if the request was served from localhost.

The problem occurs when ::Rack::URLMap#call is called with the environment set with the following variables: 'HTTP_HOST'=>'10.0.1.4:9000','SERVER_NAME'=>'localhost','SERVER_PORT'=>'9000'

The url map never makes it past the host/name check as host will always be nil when you initialize the Rack URLMap:
# From https://github.com/rack/rack/blob/master/lib/rack/urlmap.rb line 40

```
  hHost, sName, sPort = env.values_at('HTTP_HOST','SERVER_NAME','SERVER_PORT')
  @mapping.each { |host, location, match, app|
    next unless (hHost == host || sName == host \
      || (host.nil? && (hHost == sName || hHost == sName+':'+sPort)))
```

Current gems:

goliath (0.9.0)
async-rack (0.5.1)
rack (1.2.2)
rack-accept-media-types (0.9)
rack-contrib (1.1.0)
rack-respond_to (0.9.8)

The fix was to remove SERVER_NAME from the env hash.  To make this more testable I moved the rack builder block into runner.rb.

Cheers,
-Nolan
