### PR TITLE
Chunked Transfer Encoding HTTP streaming code + example

### DIFF
--- a/examples/chunked_streaming.rb
+++ b/examples/chunked_streaming.rb
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+$:<< '../lib' << 'lib'
+
+#
+# A simple HTTP streaming API which returns a 200 response for any GET request
+# and then emits numbers 1 through 10 in 1 second intervals using Chunked
+# transfer encoding, and finally closes the connection.
+#
+# Chunked transfer streaming works transparently with both browsers and
+# streaming consumers.
+#
+
+require 'goliath'
+require 'goliath/chunked_streaming_api'
+
+class ChunkedStreaming < Goliath::ChunkedStreamingAPI
+  def on_close(env)
+    env.logger.info "Connection closed."
+  end
+
+  def response(env)
+    i = 0
+    pt = EM.add_periodic_timer(1) do
+      send_chunk(env, "#{i}\n")
+      i += 1
+    end
+
+    EM.add_timer(10) do
+      pt.cancel
+
+      send_chunk(env, "!! BOOM !!\n")
+      close_stream(env)
+    end
+
+    headers = { 'Content-Type' => 'text/plain', 'X-Stream' => 'Goliath' }
+    [200, STREAMING_HEADERS.merge(headers), STREAMING]
+  end
+end

--- a/lib/goliath/chunked_streaming_api.rb
+++ b/lib/goliath/chunked_streaming_api.rb
@@ -1,0 +1,50 @@
+#
+# Provides HTTP streaming using chunked transfer encoding
+#
+# http://en.wikipedia.org/wiki/Chunked_transfer_encoding
+# http://developers.sun.com/mobility/midp/questions/chunking/
+# http://blog.port80software.com/2006/11/08/
+#
+module Goliath
+  ::Goliath::Response::STREAMING_HEADERS = { 'Transfer-Encoding' => 'chunked', }
+
+  class ChunkedStreamingAPI < Goliath::API
+    CRLF = "\r\n"
+    STREAMING = ::Goliath::Response::STREAMING
+    STREAMING_HEADERS = ::Goliath::Response::STREAMING_HEADERS
+
+    # Sends a chunk in a Chunked transfer encoding stream.
+    #
+    #     Each chunk starts with the number of octets of the data it embeds expressed
+    #     in hexadecimal followed by optional parameters (chunk extension) and a
+    #     terminating CRLF (carriage return and line feed) sequence, followed by the
+    #     chunk data. The chunk is terminated by CRLF. If chunk extensions are
+    #     provided, the chunk size is terminated by a semicolon followed with the
+    #     extension name and an optional equal sign and value
+    #     (Note: chunk extensions aren't provided yet)
+    #
+    def send_chunk env, chunk
+      chunk_len_in_hex = chunk.bytesize.to_s(16)
+      body = [chunk_len_in_hex, CRLF, chunk, CRLF ].join
+      env.stream_send(body)
+    end
+
+    # Sends the terminating chunk in a chunked transfer encoding stream, and
+    # closes the stream.
+    #
+    #     The last chunk is a zero-length chunk, with the chunk size coded as 0, but
+    #     without any chunk data section.  The final chunk may be followed by an
+    #     optional trailer of additional entity header fields that are normally
+    #     delivered in the HTTP header to allow the delivery of data that can only
+    #     be computed after all chunk data has been generated. The sender may
+    #     indicate in a Trailer header field which additional fields it will send
+    #     in the trailer after the chunks.
+    #     (Note: trailer headers aren't provided yet
+    #
+    def close_stream env
+      env.stream_send([0, CRLF, CRLF].join)
+      env.stream_close
+    end
+
+  end
+end


### PR DESCRIPTION
Added chunked-transfer encoding -- makes streaming transparent to a browser, still useful for a longrunning consumer.

for more see: 
- http://en.wikipedia.org/wiki/Chunked_transfer_encoding
- http://developers.sun.com/mobility/midp/questions/chunking/
- http://blog.port80software.com/2006/11/08/
