### PR TITLE
it handles empty input gracefully on JSON

### DIFF
--- a/lib/goliath/rack/params.rb
+++ b/lib/goliath/rack/params.rb
@@ -32,18 +32,22 @@ module Goliath
           unless post_params
             body = env['rack.input'].read
             env['rack.input'].rewind
-
-            begin
-              post_params = case(env['CONTENT_TYPE'])
-              when URL_ENCODED then
-                ::Rack::Utils.parse_nested_query(body)
-              when JSON_ENCODED then
-                MultiJson.decode(body)
-              else
-                {}
+            
+            unless body.empty?
+              begin
+                post_params = case(env['CONTENT_TYPE'])
+                when URL_ENCODED then
+                  ::Rack::Utils.parse_nested_query(body)
+                when JSON_ENCODED then
+                  MultiJson.decode(body)
+                else
+                  {}
+                end
+              rescue StandardError => e
+                raise Goliath::Validation::BadRequestError, "Invalid parameters: #{e.class.to_s}"
               end
-            rescue StandardError => e
-              raise Goliath::Validation::BadRequestError, "Invalid parameters: #{e.class.to_s}"
+            else
+              post_params = {}
             end
           end
 

--- a/spec/unit/rack/params_spec.rb
+++ b/spec/unit/rack/params_spec.rb
@@ -141,6 +141,14 @@ Berry\r
         ret = @params.retrieve_params(@env)
         ret['foo'].should == 'bar'
       end
+      
+      it "handles empty input gracefully on JSON" do
+        @env['CONTENT_TYPE'] = 'application/json'
+        @env['rack.input'] = StringIO.new
+        
+        ret = @params.retrieve_params(@env)
+        ret.should be_empty
+      end
 
       it "raises a BadRequestError on invalid JSON" do
         @env['CONTENT_TYPE'] = 'application/json'
@@ -150,7 +158,6 @@ Berry\r
 
         lambda{ @params.retrieve_params(@env) }.should raise_error(Goliath::Validation::BadRequestError)
       end
-
 
       it "doesn't parse unknown content types" do
         @env['CONTENT_TYPE'] = 'fake/form -- type'


### PR DESCRIPTION
Just one small commit to keep Goliath from blowing up on empty input when Content Type is application/json. :)
