### PR TITLE
RequiredParam can take a custom message string

### DIFF
--- a/lib/goliath/rack/validation/required_param.rb
+++ b/lib/goliath/rack/validation/required_param.rb
@@ -10,7 +10,7 @@ module Goliath
       #
       class RequiredParam
         include Goliath::Rack::Validator
-        attr_reader :type, :key
+        attr_reader :type, :key, :message
 
         # Creates the Goliath::Rack::Validation::RequiredParam validator
         #
@@ -18,15 +18,17 @@ module Goliath
         # @param opts [Hash] The validator options
         # @option opts [String] :key The key to look for in params (default: id)
         # @option opts [String] :type The type string to put in the error message. (default: :key)
+        # @option opts [String] :message The message string to display after the type string. (default: 'identifier missing')
         # @return [Goliath::Rack::Validation::RequiredParam] The validator
         def initialize(app, opts = {})
           @app = app
           @key = opts[:key] || 'id'
           @type = opts[:type] || @key.capitalize
+          @message = opts[:message] || 'identifier missing'
         end
 
         def call(env)
-          return validation_error(400, "#{@type} identifier missing") unless key_valid?(env['params'])
+          return validation_error(400, "#{@type} #{@message}") unless key_valid?(env['params'])
           @app.call(env)
         end
 

--- a/spec/unit/rack/validation/required_param_spec.rb
+++ b/spec/unit/rack/validation/required_param_spec.rb
@@ -7,29 +7,36 @@ describe Goliath::Rack::Validation::RequiredParam do
   end
 
   it 'accepts options on create' do
-    opts = { :type => 1, :key => 2 }
+    opts = { :type => 1, :key => 2, :message => 'is required' }
     lambda { Goliath::Rack::Validation::RequiredParam.new('my app', opts) }.should_not raise_error
   end
 
-  it 'defaults type and key' do
+  it 'defaults type, key and message' do
     @rp = Goliath::Rack::Validation::RequiredParam.new('app')
     @rp.key.should_not be_nil
     @rp.key.should_not =~ /^\s*$/
 
     @rp.type.should_not be_nil
     @rp.type.should_not =~ /^\s*$/
+
+    @rp.message.should == 'identifier missing'
   end
 
   describe 'with middleware' do
     before(:each) do
       @app = mock('app').as_null_object
       @env = {'params' => {}}
-      @rp = Goliath::Rack::Validation::RequiredParam.new(@app, {:type => 'Monkey', :key => 'mk'})
+      @rp = Goliath::Rack::Validation::RequiredParam.new(@app, {:type => 'Monkey', :key => 'mk', :message => 'is required'})
     end
 
     it 'stores type and key options' do
       @rp.type.should == 'Monkey'
       @rp.key.should == 'mk'
+    end
+
+    it 'calls validation_error with a custom message' do
+      @rp.should_receive(:validation_error).with(anything, 'Monkey is required')
+      @rp.call(@env)
     end
 
     it 'returns the app status, headers and body' do


### PR DESCRIPTION
I have the need to allow custom messaging using the RequiredParam middleware. Here's a patch that allows the RequiredParam to take an optional opts[:message] param that will be displayed when rendering the error instead of 'identifier missing'.
