### PR TITLE
Add comments in examples regarding Rack::ValidationError

### DIFF
--- a/examples/echo.rb
+++ b/examples/echo.rb
@@ -16,6 +16,9 @@ class Echo < Goliath::API
   use Goliath::Rack::Params             # parse & merge query and body parameters
   use Goliath::Rack::Heartbeat          # respond to /status with 200, OK (monitoring, etc)
 
+  # If you are using Golaith version <=0.9.1 you need to Goliath::Rack::ValidationError
+  # to prevent the request from remaining open after an error occurs
+  #use Goliath::Rack::ValidationError
   use Goliath::Rack::Validation::RequestMethod, %w(GET POST)           # allow GET and POST requests only
   use Goliath::Rack::Validation::RequiredParam, {:key => 'echo'}  # must provide ?echo= query or body param
 

--- a/examples/valid.rb
+++ b/examples/valid.rb
@@ -7,6 +7,10 @@ class Valid < Goliath::API
   use Goliath::Rack::Params
   use Goliath::Rack::Validation::RequiredParam, {:key => 'test'}
 
+  # If you are using Golaith version <=0.9.1 you need to use Goliath::Rack::ValidationError
+  # to prevent the request from remaining open after an error occurs
+  #use Goliath::Rack::ValidationError
+
   def response(env)
     [200, {}, 'OK']
   end


### PR DESCRIPTION
I added some inline comments to help clarify that you need to include

```
use Goliath::Rack::ValidationError
```

in version 0.9.1 and earlier. Otherwise the example code can be confusing because requests will hang due to the connection not being closed. 
