### PR TITLE
Allow to namespace the app's name

### DIFF
--- a/lib/goliath/api.rb
+++ b/lib/goliath/api.rb
@@ -23,6 +23,13 @@ module Goliath
     include Goliath::Rack::Validator
 
     class << self
+      # Catches the userland class which inherits the Goliath API
+      #
+      # In case of further subclassing, the very last class encountered is used.
+      def inherited(subclass)
+        Goliath::Application.app_class = subclass.name
+      end
+
       # Retrieves the middlewares defined by this API server
       #
       # @return [Array] array contains [middleware class, args, block]


### PR DESCRIPTION
Automatically detect which class is inheriting from Goliath::API, and configure Goliath::Application accordingly.
This avoids problems related to situations wherein the launcher is not named after the app, is located in a bootstrap folder, or is namespaced.

---

I wasn't too sure about how you might want it to get unit tested, let alone the hairy syntax used in rspec. (Still learning ruby; and only competent enough to be dangerous atm.)
