### PR TITLE
missing require for response_receiver

### DIFF
--- a/lib/goliath/synchrony/mongo_receiver.rb
+++ b/lib/goliath/synchrony/mongo_receiver.rb
@@ -1,3 +1,5 @@
+require 'goliath/synchrony/response_receiver'
+
 module Goliath
   module Synchrony
     #


### PR DESCRIPTION
This solves the following problem for me..

lib/goliath/synchrony/mongo_receiver.rb:10:in `class:MongoReceiver': uninitialized constant Goliath::Synchrony::ResponseReceiver (NameError)
