### PR TITLE
Don't use the default server port number for running tests

### DIFF
--- a/spec/integration/keepalive_spec.rb
+++ b/spec/integration/keepalive_spec.rb
@@ -3,8 +3,8 @@ require File.join(File.dirname(__FILE__), '../../', 'examples/echo')
 
 describe 'HTTP Keep-Alive support' do
   it 'serves multiple requests via single connection' do
-    with_api(Echo) do
-      conn = EM::HttpRequest.new('http://localhost:9000')
+    with_api(Echo, :port => 9901) do
+      conn = EM::HttpRequest.new('http://localhost:9901')
       r1 = conn.get(:query => {:echo => 'test'}, :keepalive => true)
 
       r1.errback { fail }

--- a/spec/integration/pipelining_spec.rb
+++ b/spec/integration/pipelining_spec.rb
@@ -13,11 +13,11 @@ end
 
 describe 'HTTP Pipelining support' do
   it 'serves multiple requests via single connection' do
-    with_api(Interleaving) do
+    with_api(Interleaving, :port => 9901) do
       start = Time.now.to_f
       res = []
 
-      conn = EM::HttpRequest.new('http://localhost:9000')
+      conn = EM::HttpRequest.new('http://localhost:9901')
       r1 = conn.aget :query => {:delay => 0.3}, :keepalive => true
       r2 = conn.aget :query => {:delay => 0.2}
 


### PR DESCRIPTION
I find it rather annoying that I can't run tests while I have a goliath server running with the default settings as the tests try to use the same port.
