### PR TITLE
Improve the way RequiredParam validates a parameter

### DIFF
--- a/lib/goliath/rack/validation/required_param.rb
+++ b/lib/goliath/rack/validation/required_param.rb
@@ -12,6 +12,13 @@ module Goliath
         include Goliath::Rack::Validator
         attr_reader :type, :key, :message
 
+        # extracted from activesupport 3.0.9
+        if defined?(Encoding) && "".respond_to?(:encode)
+          NON_WHITESPACE_REGEXP = %r![^[:space:]]!
+        else
+          NON_WHITESPACE_REGEXP = %r![^\s#{[0x3000].pack("U")}]!
+        end
+        
         # Creates the Goliath::Rack::Validation::RequiredParam validator
         #
         # @param app The app object
@@ -34,7 +41,7 @@ module Goliath
 
         def key_valid?(params)
           if !params.has_key?(key) || params[key].nil? ||
-              (params[key].is_a?(String) && params[key] =~ /^\s*$/)
+              (params[key].is_a?(String) && params[key] !~ NON_WHITESPACE_REGEXP)
             return false
           end
 
@@ -42,7 +49,7 @@ module Goliath
             unless params[key].compact.empty?
               params[key].each do |k|
                 return true unless k.is_a?(String)
-                return true unless k =~ /^\s*$/
+                return true unless k !~ NON_WHITESPACE_REGEXP
               end
             end
             return false

--- a/spec/unit/rack/validation/required_param_spec.rb
+++ b/spec/unit/rack/validation/required_param_spec.rb
@@ -91,6 +91,16 @@ describe Goliath::Rack::Validation::RequiredParam do
         @env['params']['mk'] = [1, 2, 3, 4]
         @rp.key_valid?(@env['params']).should be_true
       end
+
+      it "doesn't raise if the key provided is multiline and has blanks" do
+        @env['params']['mk'] = "my\n  \nvalue"
+        @rp.key_valid?(@env['params']).should be_true
+      end
+
+      it "doesn't raise if the key provided is an array and contains multiline with blanks" do
+        @env['params']['mk'] = ["my\n  \nvalue", "my\n  \nother\n  \nvalue"]
+        @rp.key_valid?(@env['params']).should be_true
+      end
     end
   end
 end


### PR DESCRIPTION
It changes the regular expression used to check if a parameter value is empty. The current one is not accepting multiline strings that have blank lines inside, like

```
it have a blank line,\n\n      \n\nbut it's not empty
```
