### PR TITLE
Update em-synchrony and em-mongo on gemspec.

### DIFF
--- a/goliath.gemspec
+++ b/goliath.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '>2.0'
   s.add_development_dependency 'nokogiri'
   s.add_development_dependency 'em-http-request', '>= 1.0.0.beta.1'
-  s.add_development_dependency 'em-mongo', '~> 0.3.6'
+  s.add_development_dependency 'em-mongo', '~> 0.4.0'
   s.add_development_dependency 'yajl-ruby'
   s.add_development_dependency 'rack-rewrite'
   s.add_development_dependency 'multipart_body'


### PR DESCRIPTION
I was having some problems querying mongo on synchrony. The gemspec seems to be outdated.

The problem was: "undefined method `find' for #<EventMachine::Mongo::Connection

Now works like a charm. All tests passing too.
