### PR TITLE
Added options to Goliath::Rack::Heartbeat

### DIFF
--- a/lib/goliath/rack/heartbeat.rb
+++ b/lib/goliath/rack/heartbeat.rb
@@ -7,13 +7,16 @@ module Goliath
     #  use Goliath::Rack::Heartbeat
     #
     class Heartbeat
-      def initialize(app)
-        @app = app
+      def initialize(app, opts = {})
+        @app  = app
+        @opts = opts
+        @opts[:path]     ||= '/status'
+        @opts[:response] ||= [200, {}, 'OK']
       end
 
       def call(env)
-        if env['PATH_INFO'] == '/status'
-          [200, {}, 'OK']
+        if env['PATH_INFO'] == @opts[:path]
+          @opts[:response]
         else
           @app.call(env)
         end

--- a/spec/unit/rack/heartbeat_spec.rb
+++ b/spec/unit/rack/heartbeat_spec.rb
@@ -43,5 +43,15 @@ describe Goliath::Rack::Heartbeat do
       headers.should == {}
       body.should == 'OK'
     end
+
+    it 'allows path and response to be set using options' do
+      @hb = Goliath::Rack::Heartbeat.new(@app, :path => '/isup', :response => [204, {}, nil])
+      @env['PATH_INFO'] = '/isup'
+      status, headers, body = @hb.call(@env)
+      status.should == 204
+      headers.should == {}
+      body.should == nil
+    end
   end
 end
+


### PR DESCRIPTION
Added options to Goliath::Rack::Heartbeat which takes optional heartbeat path endpoint and heartbeat response.

Example: use Goliath::Rack::Heartbeat, {:path => '/isup', :response => [204, {}, nil]}

I needed this, maybe someone else would appreciate it as well.

Best regards,
Christoffer
