### PR TITLE
reload configuration on HUP signal

### DIFF
--- a/lib/goliath/server.rb
+++ b/lib/goliath/server.rb
@@ -73,6 +73,7 @@ module Goliath
       EM.synchrony do
         trap("INT")  { EM.stop }
         trap("TERM") { EM.stop }
+        trap("HUP")  { load_config(options[:config]) }
 
         load_config(options[:config])
         load_plugins


### PR DESCRIPTION
Trap the "HUP" signal and reload the configuration when it is sent (allows changing the config without restarting the server similar as Nginx does it).

see http://groups.google.com/group/goliath-io/browse_thread/thread/e367073ff6ef571f
