### PR TITLE
Implement stub close_connection_after_write for websocket connection

### DIFF
--- a/lib/goliath/websocket.rb
+++ b/lib/goliath/websocket.rb
@@ -30,15 +30,17 @@ module Goliath
       request['query'] = env[QUERY_STRING]
 
       old_stream_send = env[STREAM_SEND]
+      old_stream_close = env[STREAM_CLOSE]
       env[STREAM_SEND]  = proc { |data| env.handler.send_text_frame(data) }
       env[STREAM_CLOSE] = proc { env.handler.close_websocket }
       env[STREAM_START] = proc { }
 
       conn = Class.new do
-        def initialize(env, parent, stream_send)
+        def initialize(env, parent, stream_send, connection_close)
           @env = env
           @parent = parent
           @stream_send = stream_send
+          @connection_close = connection_close
         end
 
         def trigger_on_open
@@ -54,12 +56,14 @@ module Goliath
         end
 
         def close_connection_after_writing
+          @connection_close.call
         end
 
         def send_data(data)
           @stream_send.call(data)
         end
-      end.new(env, self, old_stream_send)
+
+      end.new(env, self, old_stream_send, old_stream_close)
 
       upgrade_data = env[UPGRADE_DATA]
 


### PR DESCRIPTION
This pull-request naively fixes issue #103 by implementing an empty `close_connection_after_write` method.
