### PR TITLE
allow using instances in maps

### DIFF
--- a/examples/rack_routes.rb
+++ b/examples/rack_routes.rb
@@ -74,10 +74,23 @@ class Aloha < Goliath::API
   end
 end
 
+class SayMyName < Goliath::API
+  def initialize(name)
+    @name = name
+  end
+  
+  def response(env)
+    [200, {}, "Hello #{@name}"]
+  end
+end
+
 class RackRoutes < Goliath::API
   map '/version' do
     run Proc.new { |env| [200, {"Content-Type" => "text/html"}, ["Version 0.1"]] }
   end
+  
+  get '/name', SayMyName.new("Leonard")
+  get '/name2', SayMyName.new("Helena")
 
   post "/hello_world" do
     run PostHelloWorld.new

--- a/lib/goliath/api.rb
+++ b/lib/goliath/api.rb
@@ -286,8 +286,9 @@ module Goliath
     def set_event_handler!(env)
       if self.class.maps?
         response = self.class.router.recognize(env)
-        if response = self.class.router.recognize(env) and response.respond_to?(:path) and response.path.route.api_class
-          env.event_handler = response.path.route.api_class.new
+        if response = self.class.router.recognize(env) and response.respond_to?(:path) and response.path.route.api_class_or_object
+          api_class_or_object = response.path.route.api_class_or_object
+          env.event_handler = api_class_or_object.is_a?(Goliath::API) ? api_class_or_object : api_class_or_object.new
         end
       end
       env.event_handler ||= self

--- a/spec/integration/rack_routes_spec.rb
+++ b/spec/integration/rack_routes_spec.rb
@@ -14,6 +14,27 @@ describe RackRoutes do
         end
       }.to_not raise_error
     end
+    
+    it 'can map to instances' do
+      with_api(RackRoutes) do
+        get_request({:path => '/name'}, err) do |cb|
+          cb.response_header.status.should == 200
+          cb.response.should == 'Hello Leonard'
+        end        
+      end
+    end
+    
+    it 'can map to instances 2' do
+      with_api(RackRoutes) do        
+        get_request({:path => '/name2'}, err) do |cb|
+          cb.response_header.status.should == 200
+          cb.response.should == 'Hello Helena'
+        end
+        
+      end
+    end
+    
+    
 
     it 'fallback not found to missing' do
       with_api(RackRoutes) do


### PR DESCRIPTION
This patch allows this:

```
class Test < Goliath::API

  def initialize(name)
    @name = name
  end

  def response(env)
    [200, {}, [@name]]
  end
end

class Router < Goliath::API
  map '/', Test.new('yeah !')
  map '/yo', Test.new('yo !')
end
```

I needed it to specialize my api classes.
