### PR TITLE
Fix spec that broke after pull request #109

### DIFF
--- a/spec/unit/api_spec.rb
+++ b/spec/unit/api_spec.rb
@@ -23,8 +23,8 @@ describe Goliath::API do
       middlewares = c2.middlewares - base_middlewares
 
       middlewares.size.should == 2
-      middlewares[0][0].should == Goliath::Rack::DefaultMimeType
-      middlewares[1][0].should == Goliath::Rack::Params
+      middlewares[0][0].should == Goliath::Rack::Params
+      middlewares[1][0].should == Goliath::Rack::DefaultMimeType
     end
   end
 


### PR DESCRIPTION
Because the superclasses' middleware was loaded before, it broke a spec that did not expect this.
