### PR TITLE
Allow for a request to specify that it should not be logged

### DIFF
--- a/lib/goliath/constants.rb
+++ b/lib/goliath/constants.rb
@@ -50,5 +50,6 @@ module Goliath
     UPGRADE_DATA    = 'UPGRADE_DATA'
 
     GOLIATH_ENV     = 'goliath.env'
+    GOLIATH_SKIP_LOG = 'goliath.skip_log'
   end
 end

--- a/lib/goliath/rack/heartbeat.rb
+++ b/lib/goliath/rack/heartbeat.rb
@@ -16,6 +16,7 @@ module Goliath
 
       def call(env)
         if env['PATH_INFO'] == @opts[:path]
+          env[Constants::GOLIATH_SKIP_LOG] = !!@opts[:no_log]
           @opts[:response]
         else
           @app.call(env)

--- a/lib/goliath/request.rb
+++ b/lib/goliath/request.rb
@@ -171,11 +171,13 @@ module Goliath
           begin
             @response.status, @response.headers, @response.body = status, headers, body
             @response.each { |chunk| @conn.send_data(chunk) }
-            @env[RACK_LOGGER].info("Status: #{@response.status}, " +
-                                   "Content-Length: #{@response.headers['Content-Length']}, " +
-                                   "Response Time: #{"%.2f" % ((Time.now.to_f - @env[:start_time]) * 1000)}ms")
+            unless @env[GOLIATH_SKIP_LOG]
+              @env[RACK_LOGGER].info("Status: #{@response.status}, " +
+                                     "Content-Length: #{@response.headers['Content-Length']}, " +
+                                     "Response Time: #{"%.2f" % ((Time.now.to_f - @env[:start_time]) * 1000)}ms")
+            end
 
-                                   @conn.terminate_request(keep_alive)
+            @conn.terminate_request(keep_alive)
           rescue Exception => e
             server_exception(e)
           end

--- a/spec/unit/rack/heartbeat_spec.rb
+++ b/spec/unit/rack/heartbeat_spec.rb
@@ -42,6 +42,7 @@ describe Goliath::Rack::Heartbeat do
       status.should == 200
       headers.should == {}
       body.should == 'OK'
+      @env[Goliath::Constants::GOLIATH_SKIP_LOG].should == false
     end
 
     it 'allows path and response to be set using options' do
@@ -51,6 +52,13 @@ describe Goliath::Rack::Heartbeat do
       status.should == 204
       headers.should == {}
       body.should == nil
+    end
+
+    it "doesn't log if set in options" do
+      @hb = Goliath::Rack::Heartbeat.new(@app, :no_log => true)
+      @env['PATH_INFO'] = '/status'
+      @hb.call(@env)
+      @env[Goliath::Constants::GOLIATH_SKIP_LOG].should == true
     end
   end
 end


### PR DESCRIPTION
When using a load balancer with a heartbeat, the logging from this can get pretty noisy. Allow for a request to set an env key to specify that it should not be logged (unless it errors).

(I also considered just setting a null logger in env, but this would also swallow errors and seems sub-optimal.)
