### PR TITLE
Allows a string as parameter to RequestMethod

### DIFF
--- a/lib/goliath/rack/validation/request_method.rb
+++ b/lib/goliath/rack/validation/request_method.rb
@@ -21,7 +21,7 @@ module Goliath
         # @return [Goliath::Rack::Validation::RequestMethod] The validator
         def initialize(app, methods = [])
           @app = app
-          @methods = methods
+          @methods = Array(methods)
         end
 
         def call(env)

--- a/spec/unit/rack/validation/request_method_spec.rb
+++ b/spec/unit/rack/validation/request_method_spec.rb
@@ -44,4 +44,9 @@ describe Goliath::Rack::Validation::RequestMethod do
     rm = Goliath::Rack::Validation::RequestMethod.new('my app', ['GET', 'DELETE', 'HEAD'])
     rm.methods.should == ['GET', 'DELETE', 'HEAD']
   end
+  
+  it 'accepts string method on initialize' do
+    rm = Goliath::Rack::Validation::RequestMethod.new('my app', 'GET')
+    rm.methods.should == ['GET']
+  end
 end


### PR DESCRIPTION
Allow writing this:

```
use Goliath::Rack::Validation::RequestMethod, "POST"
```

instead of these:

```
use Goliath::Rack::Validation::RequestMethod, %w(POST)
use Goliath::Rack::Validation::RequestMethod, ['POST']
```
