### PR TITLE
param: clone the opts array

### DIFF
--- a/lib/goliath/rack/validation/param.rb
+++ b/lib/goliath/rack/validation/param.rb
@@ -67,6 +67,9 @@ module Goliath
         #
         # @return [Goliath::Rack::Validation::Param] The validator
         def initialize(app, opts = {})
+          # do not touch the original hash
+          opts = opts.clone
+          
           @app = app
           @optional = opts.delete(:optional) || false
           @key = opts.delete(:key) || 'id'


### PR DESCRIPTION
After doing some tests with the new Param middleware it appears that the hash is reused even if I am not sure where and how, so here is a patch to clone it before removing its keys.
