### PR TITLE
param: remove default value for key

### DIFF
--- a/lib/goliath/rack/validation/param.rb
+++ b/lib/goliath/rack/validation/param.rb
@@ -69,7 +69,9 @@ module Goliath
         def initialize(app, opts = {})
           @app = app
           @optional = opts.delete(:optional) || false
-          @key = opts.delete(:key) || 'id'
+          @key = opts.delete(:key)
+          raise Exception.new("key option required") unless @key
+          
           @type = opts.delete(:type) || @key
           @message = opts.delete(:message) || 'identifier missing'
           @default = opts.delete(:default)


### PR DESCRIPTION
After doing some debug with the master branch on a goliath application I feel like testing for the presence of "id" when your options hash is empty or there is no key present is a really weird behavior (I got this when working on pull request #128 ).

``` ruby
class SomeAPI < Goliath::API
  use Goliath::Rack::Params
  use Goliath::Rack::Validation::Param

end
```

If you write this code without my patch it will test if an "id" key is present, with my patch you get a proper insult as your deserve for writing this ^^
