### PR TITLE
move "require 'em-websocket-client'" to test_helper_ws

### DIFF
--- a/lib/goliath/test_helper.rb
+++ b/lib/goliath/test_helper.rb
@@ -1,6 +1,5 @@
 require 'em-synchrony'
 require 'em-synchrony/em-http'
-require 'em-websocket-client'
 
 require 'goliath/server'
 require 'goliath/rack'

--- a/lib/goliath/test_helper_ws.rb
+++ b/lib/goliath/test_helper_ws.rb
@@ -1,3 +1,5 @@
+require 'em-websocket-client'
+
 module Goliath
   module TestHelper
     class WSHelper


### PR DESCRIPTION
remove development dependency "em-websocket-client" from test_helper and add it to test_helper_ws.

It finishes bcedd2347fdc3bea58c011f494e76c398bdeae31 (Split websocket test helper in its own file) .
