### PR TITLE
router: transform extract keys from symbol to strings

### DIFF
--- a/lib/goliath/rack/builder.rb
+++ b/lib/goliath/rack/builder.rb
@@ -35,7 +35,11 @@ module Goliath
               route.to do |env|
                 builder = Builder.new
                 env['params'] ||= {}
-                env['params'].merge!(env['router.params']) if env['router.params']
+                
+                if env['router.params']
+                  # transform the keys into string
+                  env['params'].merge!( Hash[env['router.params'].map{|k,v| [k.to_s, v] }] )
+                end
 
                 builder.params = builder.retrieve_params(env)
                 builder.instance_eval(&blk) if blk


### PR DESCRIPTION
if you use this in your api:

``` ruby
map("/item/:id", MyAPIClass)
```

It was accessible as params[:id], now you can access it as params['id'].
The reason for this changes is to match the behavior of the Params middleware (which fills the params hash with string keys) and allow the use of the new and shiny Param middleware to validate that those keys are present without resorting to this:

``` ruby
use Goliath::Rack::Validation::Param, :key => [:id]
```

whi is rather ugly and not really intuitive.
