### PR TITLE
Add option to log to the null logger in the Heartbeat middleware

### DIFF
--- a/lib/goliath/rack/heartbeat.rb
+++ b/lib/goliath/rack/heartbeat.rb
@@ -16,7 +16,7 @@ module Goliath
 
       def call(env)
         if env['PATH_INFO'] == @opts[:path]
-          env[Goliath::Constants::RACK_LOGGER] = Log4r::Logger.root if @opts[:no_log]
+          env[Goliath::Constants::RACK_LOGGER] = Log4r::Logger.root unless @opts[:log]
 
           @opts[:response]
         else

--- a/spec/unit/rack/heartbeat_spec.rb
+++ b/spec/unit/rack/heartbeat_spec.rb
@@ -53,11 +53,17 @@ describe Goliath::Rack::Heartbeat do
       body.should == nil
     end
 
-    it 'skips logging the request if asked' do
+    it 'does not log the request by default' do
       @env['PATH_INFO'] = '/status'
-      @hb = Goliath::Rack::Heartbeat.new(@app, :no_log => true)
       @hb.call(@env)
       @env[Goliath::Constants::RACK_LOGGER].should == Log4r::Logger.root
+    end
+
+    it 'logs the request only if asked' do
+      @env['PATH_INFO'] = '/status'
+      @hb = Goliath::Rack::Heartbeat.new(@app, :log => true)
+      @hb.call(@env)
+      @env[Goliath::Constants::RACK_LOGGER].should_not == Log4r::Logger.root
     end
   end
 end


### PR DESCRIPTION
Add a :no_log option for the Heartbeat middleware that will log to the null logger.
