### PR TITLE
HttpLog specs are invalid

### DIFF
--- a/lib/goliath/test_helper.rb
+++ b/lib/goliath/test_helper.rb
@@ -45,7 +45,8 @@ module Goliath
       s.app = Goliath::Rack::Builder.build(api, s.api)
       s.api.options_parser(op, options)
       s.options = options
-      s.port = @test_server_port = port
+      s.port = port
+      @test_server_port = s.port if blk
       s.start(&blk)
       s
     end


### PR DESCRIPTION
The issue lies in the following snippet of code:

``` ruby
it 'responds to requests' do
  with_api(HttpLog, api_options) do |api|
    server(Responder, 8080)
    mock_mongo(api)

    get_request({}, err) do |c|
      c.response_header.status.should == 200
    end
  end
end
```

Anytime you nest a `server` call inside a `with_api` block it will overwrite the port used in the request methods. Although the tests pass, they aren't correct. The request goes directly to the `Responder` instead of the `HttpLog`.

**Steps to reproduce:**

1.) Add some debug flags

```
diff --git a/examples/http_log.rb b/examples/http_log.rb
index 1fa4d85..389bfd0 100755
--- a/examples/http_log.rb
+++ b/examples/http_log.rb
@@ -23,6 +23,7 @@ class HttpLog < Goliath::API
   end

   def response(env)
+    puts "HttpLog#response"
     start_time = Time.now.to_f

     params = {:head => env['client-headers'], :query => env.params}
diff --git a/spec/integration/http_log_spec.rb b/spec/integration/http_log_spec.rb
index 37b3d72..e3db52d 100644
--- a/spec/integration/http_log_spec.rb
+++ b/spec/integration/http_log_spec.rb
@@ -9,6 +9,7 @@ class Responder < Goliath::API
   end

   def response(env)
+    puts "Responder#response"
     query_params = env.params.collect { |param| param.join(": ") }
     query_headers = env['client-headers'].collect { |param| param.join(": ") }
```

2.) Run the `http_log_spec`.

```
$ bundle exec rspec spec/integration/http_log_spec.rb 
Responder#response
.Responder#response
..Responder#response
.Responder#response
.Responder#response
.Responder#response
.Responder#response
.

Finished in 0.02944 seconds
8 examples, 0 failures
```

You'll see that it never actually hits the HttpLog API.

d746cefe49c1f4c3766d27289e92448a23b39161 fixes this to work as intended.

```
$ bundle exec rspec spec/integration/http_log_spec.rb 
HttpLog#response
Responder#response
.HttpLog#response
Responder#response
..HttpLog#response
Responder#response
.HttpLog#response
Responder#response
.HttpLog#response
Responder#response
.HttpLog#response
Responder#response
.HttpLog#response
Responder#response
.

Finished in 0.08122 seconds
8 examples, 0 failures
```
