### PR TITLE
closes #154: Server header is always set by Response

### DIFF
--- a/lib/goliath/rack/render.rb
+++ b/lib/goliath/rack/render.rb
@@ -31,7 +31,6 @@ module Goliath
         end
 
         extra = { 'Content-Type' => get_content_type(env),
-                  'Server' => 'PostRank Goliath API Server',
                   'Vary' => [headers.delete('Vary'), 'Accept'].compact.join(',') }
 
         [status, extra.merge(headers), body]


### PR DESCRIPTION
Thanks to @igrigorik noticing Server header was set in two places.
