### PR TITLE
Allows you to test `PATCH` endpoints

### DIFF
--- a/lib/goliath/test_helper.rb
+++ b/lib/goliath/test_helper.rb
@@ -152,7 +152,7 @@ module Goliath
     # @param errback [Proc] An error handler to attach
     # @param blk [Proc] The callback block to execute
     def patch_request(request_data = {}, errback = nil, &blk)
-      req = create_test_request(request_data).put(request_data)
+      req = create_test_request(request_data).patch(request_data)
       hookup_request_callbacks(req, errback, &blk)
     end
     


### PR DESCRIPTION
This patch let's you issue a `patch_request`  in your tests so you can test those endpoints which accept this HTTP method.

Since `goliath/test_helper` depends on `em-http-request`, I have an open pull request to that library too, which needs to be merged in before this pull request will work properly. That pull request is here: https://github.com/igrigorik/em-http-request/pull/181 (for reference)
