### PR TITLE
Load plugins in the test server

### DIFF
--- a/lib/goliath/test_helper.rb
+++ b/lib/goliath/test_helper.rb
@@ -46,6 +46,7 @@ module Goliath
       s.api.options_parser(op, options)
       s.options = options
       s.port = port
+      s.plugins = api.plugins
       @test_server_port = s.port if blk
       s.start(&blk)
       s


### PR DESCRIPTION
Currently if you have a status hash value that is set in a plugin that server relies upon it will not get set when you test the server using with_api or server.
