### PR TITLE
Stop relying on http_parser.rb to provide query, path and fragment.

### DIFF
--- a/lib/goliath/request.rb
+++ b/lib/goliath/request.rb
@@ -4,6 +4,7 @@ require 'goliath/response'
 require 'goliath/validation'
 require 'async_rack'
 require 'stringio'
+require 'uri'
 
 module Goliath
   # Goliath::Request is responsible for processing a request and returning
@@ -86,14 +87,15 @@ module Goliath
         @env[SERVER_PORT] = port if port
       end
 
+      uri = URI(parser.request_url)
       @env[REQUEST_METHOD]  = parser.http_method
       @env[REQUEST_URI]     = parser.request_url
-      @env[QUERY_STRING]    = parser.query_string
+      @env[QUERY_STRING]    = uri.query
       @env[HTTP_VERSION]    = parser.http_version.join('.')
-      @env[SCRIPT_NAME]     = parser.request_path
-      @env[REQUEST_PATH]    = parser.request_path
-      @env[PATH_INFO]       = parser.request_path
-      @env[FRAGMENT]        = parser.fragment
+      @env[SCRIPT_NAME]     = uri.path
+      @env[REQUEST_PATH]    = uri.path
+      @env[PATH_INFO]       = uri.path
+      @env[FRAGMENT]        = uri.fragment
 
       yield if block_given?
 


### PR DESCRIPTION
The http_parser.rb API will be changing once it updates it's upstream libraries. It'll no longer provide the query, path and fragment methods so we should use URI.parse to get these.
