### PR TITLE
stream_close for websocket bug

### DIFF
--- a/lib/goliath/env.rb
+++ b/lib/goliath/env.rb
@@ -64,8 +64,8 @@ module Goliath
 
     # If the API is a streaming API this will be executed by the API to signal that
     # the stream is complete. This will close the connection with the client.
-    def stream_close
-      self[STREAM_CLOSE].call
+    def stream_close *args
+      self[STREAM_CLOSE].call(args)
     end
 
     # Sends a chunk in a Chunked transfer encoding stream.

--- a/lib/goliath/websocket.rb
+++ b/lib/goliath/websocket.rb
@@ -32,7 +32,7 @@ module Goliath
       old_stream_send = env[STREAM_SEND]
       old_stream_close = env[STREAM_CLOSE]
       env[STREAM_SEND]  = proc { |data| env.handler.send_text_frame(data) }
-      env[STREAM_CLOSE] = proc { env.handler.close_websocket }
+      env[STREAM_CLOSE] = proc { |code, body| env.handler.close_websocket(code, body) }
       env[STREAM_START] = proc { }
 
       conn = Class.new do


### PR DESCRIPTION
Hello.

I found that `stream_close` doesn't work with latest version of `em-websocket`, due to changes in the method `close_websocket`. Now it must be called with parameters.
