### PR TITLE
Allows parsing of Content-type: text/plain, which is what IE8+ will send when using XDomainRequest

### DIFF
--- a/lib/goliath/rack/params.rb
+++ b/lib/goliath/rack/params.rb
@@ -5,6 +5,7 @@ module Goliath
   module Rack
     URL_ENCODED = %r{^application/x-www-form-urlencoded}
     JSON_ENCODED = %r{^application/json}
+    TEXT_ENCODED = %r{^text/plain}
 
     # A middle ware to parse params. This will parse both the
     # query string parameters and the body and place them into
@@ -30,10 +31,16 @@ module Goliath
                   post_params = case(env['CONTENT_TYPE'])
                   when URL_ENCODED then
                     ::Rack::Utils.parse_nested_query(body)
+                  when TEXT_ENCODED then
+                    # assume this comes from browser-like software like IE8 and IE9 and attempt to parse it as URL encoded
+                    ::Rack::Utils.parse_nested_query(body)
                   when JSON_ENCODED then
                     MultiJson.decode(body)
                   else
-                    {}
+                    # assume this comes from browser-like software like IE8 and IE9 and attempt to parse it as URL encoded
+                    # This should really be handled as an option that is either set in config or passed as variable to server
+                    # not sure which...
+                    ::Rack::Utils.parse_nested_query(body)
                   end
                 rescue StandardError => e
                   raise Goliath::Validation::BadRequestError, "Invalid parameters: #{e.class.to_s}"


### PR DESCRIPTION
When you're trying to get anything remotely ajaxy working on IE8+, you end up having to rely on a custom library they use in JS called XDomainRequest. When Goliath is an API server for another app, this is very likely to emerge.

XDomainRequest will only allow you to set Content-Type: text/plain on the outbound, but many jQuery libraries and utilities built to help you encapsulate that XDomainRequest nonsense inside jQuery.ajax() calls will allow Content-Type to remain empty. 

This patch allows Goliath to handle both cases -- when it's set explicitly and when it's left empty.

The empty case should probably be wrapped around a conditional so that Goliath server admins who don't want to assume that can turn that behavior on/off, but I'm not sure where that would be best (in server environment variables or in config variables)
