### PR TITLE
Fix deprecated MultiJson calls

### DIFF
--- a/examples/params.rb
+++ b/examples/params.rb
@@ -7,7 +7,7 @@ require 'multi_json'
 class CustomJSON
   def coerce(value, opts={})
     begin
-      MultiJson.decode(value)
+      MultiJson.load(value)
     rescue
       return opts[:default] if opts[:default]
       raise Goliath::Rack::Validation::FailedCoerce.new([400, {}, "Invalid JSON"])

--- a/lib/goliath/rack/formatters/json.rb
+++ b/lib/goliath/rack/formatters/json.rb
@@ -13,7 +13,7 @@ module Goliath
 
         def post_process(env, status, headers, body)
           if json_response?(headers)
-            body = [MultiJson.encode(body)]
+            body = [MultiJson.dump(body)]
           end
           [status, headers, body]
         end

--- a/lib/goliath/rack/params.rb
+++ b/lib/goliath/rack/params.rb
@@ -31,7 +31,7 @@ module Goliath
                   when URL_ENCODED then
                     ::Rack::Utils.parse_nested_query(body)
                   when JSON_ENCODED then
-                    MultiJson.decode(body)
+                    MultiJson.load(body)
                   else
                     {}
                   end

--- a/lib/goliath/rack/validation/param.rb
+++ b/lib/goliath/rack/validation/param.rb
@@ -17,7 +17,7 @@ module Goliath
       #
       # class CustomJSON
       #   def coerce(value, opts={})
-      #     MultiJson.decode(value)
+      #     MultiJson.load(value)
       #   end
       # end
       #


### PR DESCRIPTION
MultiJson has deprecated `encode`/`decode` in favor of `dump`/`load`.
