### PR TITLE
Remove restrictions on environments

### DIFF
--- a/lib/goliath/api.rb
+++ b/lib/goliath/api.rb
@@ -49,7 +49,7 @@ module Goliath
           @middlewares.unshift([::Goliath::Rack::DefaultResponseFormat, nil, nil])
           @middlewares.unshift([::Rack::ContentLength, nil, nil])
 
-          if Goliath.dev? && !@middlewares.detect {|mw| mw.first == ::Rack::Reloader}
+          if Goliath.env?(:development) && !@middlewares.detect {|mw| mw.first == ::Rack::Reloader}
             @middlewares.unshift([::Rack::Reloader, 0, nil])
           end
 

--- a/lib/goliath/application.rb
+++ b/lib/goliath/application.rb
@@ -3,7 +3,7 @@ require 'goliath/runner'
 require 'goliath/rack'
 
 # Pre-load the goliath environment so it's available as we try to parse the class.
-# This means we can use Goliath.dev? or Goliath.prod? in the use statements.
+# This means we can use Goliath.env?(:development) or Goliath.env?(:produdction) in the use statements.
 #
 # Note, as implmented, you have to have -e as it's own flag, you can't do -sve dev
 # as it won't pickup the e flag.
@@ -91,7 +91,7 @@ module Goliath
     # @param args [Array] Any arguments to append to the path
     # @return [String] path for the given arguments
     def self.root_path(*args)
-      return app_path(args) if Goliath.test?
+      return app_path(args) if Goliath.env?(:test)
 
       @root_path ||= File.expand_path("./")
       File.join(@root_path, *args)

--- a/lib/goliath/deprecated/environment_helpers.rb
+++ b/lib/goliath/deprecated/environment_helpers.rb
@@ -1,0 +1,25 @@
+module Goliath
+  #
+  #
+  # Deprecated helper methods for all pre-defined environments,
+  #
+  module EnvironmentHelpers
+
+    ENVIRONMENTS = [:development, :production, :test, :staging]
+
+    # for example:
+    #
+    #   def development?
+    #     env? :development
+    #   end
+    ENVIRONMENTS.each do |e|
+      define_method "#{e}?" do
+        warn "[DEPRECATION] `Goliath.#{e}?` is deprecated.  Please use `Goliath.env?(#{e})` instead."
+        env? e
+      end
+    end
+
+    alias :prod? :production?
+    alias :dev? :development?
+  end
+end

--- a/lib/goliath/goliath.rb
+++ b/lib/goliath/goliath.rb
@@ -3,10 +3,13 @@ require 'http/parser'
 require 'async_rack'
 require 'goliath/constants'
 require 'goliath/version'
+require 'goliath/deprecated/environment_helpers'
 
 # The Goliath Framework
 module Goliath
   module_function
+
+  extend EnvironmentHelpers
 
   # Retrieves the current goliath environment
   #
@@ -17,45 +20,21 @@ module Goliath
 
   # Sets the current goliath environment
   #
-  # @param [String|Symbol] the environment symbol
+  # @param [String|Symbol] env the environment symbol
   def env=(e)
     es = case(e.to_sym)
     when :dev  then :development
     when :prod then :production
     else e.to_sym
     end
+
     @env = es
   end
 
-  # Determines if we are in the production environment
-  #
-  # @return [Boolean] true if current environment is production, false otherwise
-  def prod?
-    env == :production
-  end
-
-  # Determines if we are in the development environment
-  #
-  # @return [Boolean] true if current environment is development, false otherwise
-  def dev?
-    env == :development
-  end
-
-  # Determines if we are in a custom environment
+  # Determines if we are in a particular environment
   #
   # @return [Boolean] true if current environment matches, false otherwise
-  def method_missing(name, *args)
-    if name[-1] == "?"
-      env == name[0..-2].to_sym
-    else
-      super
-    end
-  end
-
-  # Method missing implementation responds to predicate methods
-  #
-  # @return [Boolean] true if argument is a predicate method
-  def respond_to?(method)
-    method[-1] == "?" || super
+  def env?(e)
+    env == e.to_sym
   end
 end

--- a/lib/goliath/runner.rb
+++ b/lib/goliath/runner.rb
@@ -142,7 +142,7 @@ module Goliath
     #
     # @return [Nil]
     def run
-      unless Goliath.test?
+      unless Goliath.env?(:test)
         $LOADED_FEATURES.unshift(File.basename($0))
         Dir.chdir(File.expand_path(File.dirname($0)))
       end


### PR DESCRIPTION
This commit removes the restriction on environment names, allowing the use of custom environments names.

I couldn't spot a reason for restricting environment names, but feel free to let me know if there is one :)
