### PR TITLE
By providing the binding and filename, if an exception is thrown within ...

### DIFF
--- a/lib/goliath/server.rb
+++ b/lib/goliath/server.rb
@@ -114,7 +114,8 @@ module Goliath
       file ||= "#{config_dir}/#{api_name}.rb"
       return unless File.exists?(file)
 
-      eval(IO.read(file))
+      proc = Proc.new {} # create proc to grab binding
+      eval(IO.read(file), proc.binding, file)
     end
 
     # Retrieves the configuration directory for the server


### PR DESCRIPTION
...eval, it will show the proper backtrace rather than saying it just originated within eval()

For example, this is what happened before this commit:

```
/Users/mike/.rvm/gems/ruby-1.9.3-p0/gems/goliath-0.9.4/lib/goliath/server.rb:114:in `eval': wrong number of arguments (1 for 2) (ArgumentError)
```

and after the commit:

```
/Users/mike/.rvm/gems/ruby-1.9.3-p0/gems/ffi-rzmq-0.9.3/lib/ffi-rzmq/socket.rb:372:in `getsockopt': wrong number of arguments (1 for 2) (ArgumentError)
```
