### PR TITLE
Options Requests in Tests

### DIFF
--- a/lib/goliath/test_helper.rb
+++ b/lib/goliath/test_helper.rb
@@ -107,7 +107,7 @@ module Goliath
       req.errback { stop }
     end
 
-    # Make a HEAD request the currently launched API.
+    # Make a HEAD request against the currently launched API.
     #
     # @param request_data [Hash] Any data to pass to the HEAD request.
     # @param errback [Proc] An error handler to attach
@@ -117,7 +117,7 @@ module Goliath
       hookup_request_callbacks(req, errback, &blk)
     end
 
-    # Make a GET request the currently launched API.
+    # Make a GET request against the currently launched API.
     #
     # @param request_data [Hash] Any data to pass to the GET request.
     # @param errback [Proc] An error handler to attach
@@ -127,7 +127,7 @@ module Goliath
       hookup_request_callbacks(req, errback, &blk)
     end
 
-    # Make a POST request the currently launched API.
+    # Make a POST request against the currently launched API.
     #
     # @param request_data [Hash] Any data to pass to the POST request.
     # @param errback [Proc] An error handler to attach
@@ -147,7 +147,7 @@ module Goliath
       hookup_request_callbacks(req, errback, &blk)
     end
 
-    # Make a PATCH request the currently launched API.
+    # Make a PATCH request against the currently launched API.
     #
     # @param request_data [Hash] Any data to pass to the PUT request.
     # @param errback [Proc] An error handler to attach
@@ -157,7 +157,7 @@ module Goliath
       hookup_request_callbacks(req, errback, &blk)
     end
 
-    # Make a DELETE request the currently launched API.
+    # Make a DELETE request against the currently launched API.
     #
     # @param request_data [Hash] Any data to pass to the DELETE request.
     # @param errback [Proc] An error handler to attach
@@ -167,7 +167,7 @@ module Goliath
       hookup_request_callbacks(req, errback, &blk)
     end
 
-    # Make an OPTIONS request the currently launched API.
+    # Make an OPTIONS request against the currently launched API.
     #
     # @param request_data [Hash] Any data to pass to the OPTIONS request.
     # @param errback [Proc] An error handler to attach


### PR DESCRIPTION
Adds the ability to make test requests using the OPTIONS HTTP method. Goliath already allows you to respond to this method, but you couldn't verify that in your specs.

This patch depends on igrigorik/em-http-request#193 being pulled, since that is the http client being used by the test_helper. Once that's in place you'll be able to test that your endpoints properly respond to OPTIONS requests, which are used by JavaScript clients as a pre-flight check on the ALLOWED_METHODS header when making non-idempodent requests such as PUT and DELETE (not-including POST).
