### PR TITLE
Force encoding to binary in order to avoid conflict with the over-the-wire encoding.

### DIFF
--- a/lib/goliath/websocket.rb
+++ b/lib/goliath/websocket.rb
@@ -31,7 +31,12 @@ module Goliath
 
       old_stream_send = env[STREAM_SEND]
       old_stream_close = env[STREAM_CLOSE]
-      env[STREAM_SEND]  = proc { |data| env.handler.send_text_frame(data) }
+      env[STREAM_SEND]  = proc do |data|
+        if data.respond_to?(:force_encoding)
+          data.force_encoding("BINARY")
+        end
+        env.handler.send_text_frame(data)
+      end
       env[STREAM_CLOSE] = proc { |code, body| env.handler.close_websocket(code, body) }
       env[STREAM_START] = proc { }
 


### PR DESCRIPTION
If sending a string, force encoding to binary in order to avoid conflict with the over-the-wire encoding.
