### PR TITLE
Reduce size of built .gem file

### DIFF
--- a/goliath.gemspec
+++ b/goliath.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |s|
     s.add_development_dependency 'rb-fsevent'
   end
 
-  ignores = File.readlines(".gitignore").grep(/\S+/).map {|i| i.chomp }
+  ignores = File.readlines(".gitignore").grep(/\S+/).map {|i| i.chomp }.map {|i| File.directory?(i) ? i.sub(/\/?$/, '/*') : i }
   dotfiles = [".gemtest", ".gitignore", ".rspec", ".yardopts"]
 
   s.files = Dir["**/*"].reject {|f| File.directory?(f) || ignores.any? {|i| File.fnmatch(i, f) } } + dotfiles


### PR DESCRIPTION
Now build goliath-*.gem file is about 16MB, it contains `pkg/` directory, actual code is only 88KB. I fixed ignoring files from `.gitignore`

``` ruby
File.fnmatch('pkg/', 'pkg/goliath-1.0.0.beta.1.gem') # => false
File.fnmatch('pkg/*', 'pkg/goliath-1.0.0.beta.1.gem') # => true
```
