### PR TITLE
Make it possible to disable server startup in the at_exit block

### DIFF
--- a/lib/goliath/application.rb
+++ b/lib/goliath/application.rb
@@ -24,7 +24,7 @@ module Goliath
 
     module_function
 
-    # Control wheter or not the application will be run using an at_exit block.
+    # Control whether or not the application will be run using an at_exit block.
     class << self
       attr_accessor :run_app_on_exit
       alias_method :run_app_on_exit?, :run_app_on_exit


### PR DESCRIPTION
This hook is executed after any program that load Goliath::Application. 

It made my sprockets-for-goliath gem specs to fail (see [failed travis build](https://travis-ci.org/moretea/goliath_rack_sprockets/jobs/3201970/#L64)).
