### PR TITLE
Params middleware errors when a JSON array is posted

### DIFF
--- a/lib/goliath/rack/params.rb
+++ b/lib/goliath/rack/params.rb
@@ -31,7 +31,12 @@ module Goliath
                   when URL_ENCODED then
                     ::Rack::Utils.parse_nested_query(body)
                   when JSON_ENCODED then
-                    MultiJson.load(body)
+                    json = MultiJson.load(body)
+                    if json.is_a?(Hash)
+                      json
+                    else
+                      {'_json' => json}
+                    end
                   else
                     {}
                   end

--- a/spec/unit/rack/params_spec.rb
+++ b/spec/unit/rack/params_spec.rb
@@ -142,6 +142,16 @@ Berry\r
         ret['foo'].should == 'bar'
       end
 
+      it "parses json that does not evaluate to a hash" do
+        @env['CONTENT_TYPE'] = 'application/json'
+        @env['rack.input'] = StringIO.new
+        @env['rack.input'] << %|["foo","bar"]|
+        @env['rack.input'].rewind
+
+        ret = @params.retrieve_params(@env)
+        ret['_json'].should == ['foo', 'bar']
+      end
+
       it "handles empty input gracefully on JSON" do
         @env['CONTENT_TYPE'] = 'application/json'
         @env['rack.input'] = StringIO.new


### PR DESCRIPTION
The middleware should not assume that the JSON is always going to evaluate to a hash.
