### PR TITLE
set up the API before running the server

### DIFF
--- a/lib/goliath/runner.rb
+++ b/lib/goliath/runner.rb
@@ -293,6 +293,7 @@ module Goliath
        log.info("Starting server on #{@address}:#{@port} in #{Goliath.env} mode. Watch out for stones.")
 
        server = setup_server(log)
+       server.api.setup if server.api.respond_to?(:setup)
        server.start
      end
 

--- a/spec/unit/runner_spec.rb
+++ b/spec/unit/runner_spec.rb
@@ -108,6 +108,16 @@ describe Goliath::Runner do
       end
     end
 
+    it 'sets up the api if that implements the #setup method' do
+      server_mock = mock("Server").as_null_object
+      server_mock.api.should_receive(:setup)
+
+      Goliath::Server.stub!(:new).and_return(server_mock)
+
+      @r.stub!(:load_config).and_return({})
+      @r.send(:run_server)
+    end
+
     it 'runs the server' do
       server_mock = mock("Server").as_null_object
       server_mock.should_receive(:start)


### PR DESCRIPTION
Adds support to run setup tasks before the server actually starts and accepts connections. In our case that was starting up the NewRelic agent etc.

Note that while these setup scripts could be run in the app.rb file as well that could sometimes cause problems as when run in demonized mode, the server will run in a different process than the app.rb files itself which can sometimes cause problems (e.g. in the case of NewRelic it would start the NewRelic agent in the process that is exited when the server process is forked later).
