### PR TITLE
Add support for subdomains in test_helper requests

### DIFF
--- a/lib/goliath/test_helper.rb
+++ b/lib/goliath/test_helper.rb
@@ -178,11 +178,11 @@ module Goliath
     end
 
     def create_test_request(request_data)
+      domain = request_data.delete(:domain) || "localhost:#{@test_server_port}"
       path = request_data.delete(:path) || ''
-      subdomain = request_data.delete(:subdomain) || ''
       opts = request_data.delete(:connection_options) || {}
 
-      EM::HttpRequest.new("http://#{subdomain}localhost:#{@test_server_port}#{path}", opts)
+      EM::HttpRequest.new("http://#{domain}#{path}", opts)
     end
 
     private


### PR DESCRIPTION
The current test_helper only allows requests straight to localhost. This change adds support for subdomains in the request_data hash of the various request methods

``` ruby
with_api(MyAwesomeAPI) do
  get_request(:subdomain => 'notifications.') do . . .
```
