### PR TITLE
lock the em-websocket to a working version

### DIFF
--- a/goliath.gemspec
+++ b/goliath.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'eventmachine', '>= 1.0.0.beta.4'
   s.add_dependency 'em-synchrony', '>= 1.0.0'
-  s.add_dependency 'em-websocket'
+  s.add_dependency 'em-websocket', "0.3.8"
   s.add_dependency 'http_parser.rb', '0.5.3'
   s.add_dependency 'log4r'
 


### PR DESCRIPTION
The EM::Websocket::HandlerFactory was removed in 0.4.0, this gets the websocket example and specs passing again. Will open another PR to upgrade em-websocket to use the new handshake api.
