### PR TITLE
changed logger error messages to MRI format

### DIFF
--- a/lib/goliath/api.rb
+++ b/lib/goliath/api.rb
@@ -175,8 +175,11 @@ module Goliath
         env[ASYNC_CALLBACK].call(validation_error(e.status_code, e.message))
 
       rescue Exception => e
-        env.logger.error(e.message)
-        env.logger.error(e.backtrace.join("\n"))
+        logthis = "#{e.backtrace[0]}: #{e.message} (#{e.class})\n"
+        e.backtrace[1..-1].each do |bt|
+          logthis += "    from #{bt}\n"
+        end
+        env.logger.error(logthis)
         env[RACK_EXCEPTION] = e
 
         message = Goliath.env?(:production) ? 'An error happened' : e.message


### PR DESCRIPTION
this is a small trivial change
to mimic MRI error messages in logger
after spending years and years looking at MRI error messages
i wanted to see the same format again
