### PR TITLE
added on_exit hook to api

### DIFF
--- a/lib/goliath/server.rb
+++ b/lib/goliath/server.rb
@@ -107,6 +107,9 @@ module Goliath
 
     # Stops the server running.
     def stop
+      if @api.respond_to?(:on_exit)
+        @api.on_exit
+      end
       logger.info('Stopping server...')
       EM.stop
     end


### PR DESCRIPTION
i could not find this hook
it executes when the server get an INT or TERM signal

what i wanted to accomplish is to marshal out data when the server stops
is there a better way to do it?

here is how to use it:

```
require 'goliath'

class HelloWorld < Goliath::API
  def response(env)
    [200, {}, "hello world"]
  end

  def on_exit
    puts 'goodbye world'
  end
end
```
