### PR TITLE
Avoid mutex from trap context Ruby2

### DIFF
--- a/lib/goliath/server.rb
+++ b/lib/goliath/server.rb
@@ -107,7 +107,6 @@ module Goliath
 
     # Stops the server running.
     def stop
-      logger.info('Stopping server...')
       EM.stop
     end
 


### PR DESCRIPTION
Simple hack to avoid `'lock': can't be called from trap context (ThreadError)` appearing on Ruby2.
