### PR TITLE
Use an empty string for SCRIPT_NAME.

### DIFF
--- a/lib/goliath/request.rb
+++ b/lib/goliath/request.rb
@@ -94,7 +94,7 @@ module Goliath
         @env[REQUEST_URI]     = parser.request_url
         @env[QUERY_STRING]    = uri.query
         @env[HTTP_VERSION]    = parser.http_version.join('.')
-        @env[SCRIPT_NAME]     = uri.path
+        @env[SCRIPT_NAME]     = ""
         @env[REQUEST_PATH]    = uri.path
         @env[PATH_INFO]       = uri.path
         @env[FRAGMENT]        = uri.fragment


### PR DESCRIPTION
Rack's `path` method returns `script_name + path_info`, see [here](https://github.com/rack/rack/blob/master/lib/rack/request.rb#L331)

If we set both variables to uri.path we end up with a path repeated when calling the `path` method.

``` ruby
env = {"SCRIPT_NAME" => "/foo/bar", "PATH_INFO" => "/foo/bar"}
req = Rack::Request.new(env)
req.path #=> "/foo/bar/foo/bar"
```

According to Rack [SPEC](https://github.com/rack/rack/blob/master/SPEC#L24), we should set this to the path were our application was mounted, but I'm not sure if we could know that.

Setting this value to an empty string make Rack's `path` method work as expected. 
