### PR TITLE
Update required http_parser.rb gem version to prevent collision with em-http-request

### DIFF
--- a/goliath.gemspec
+++ b/goliath.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'eventmachine', '>= 1.0.0.beta.4'
   s.add_dependency 'em-synchrony', '>= 1.0.0'
   s.add_dependency 'em-websocket', "0.3.8"
-  s.add_dependency 'http_parser.rb', '0.6.0.beta.2'
+  s.add_dependency 'http_parser.rb', '0.6.0'
   s.add_dependency 'log4r'
 
   s.add_dependency 'rack', '>=1.2.2'


### PR DESCRIPTION
This change fixes version mismatch:

```
Bundler could not find compatible versions for gem "http_parser.rb":
  In Gemfile:
    em-http-request (>= 0) ruby depends on
      http_parser.rb (>= 0.6.0) ruby

    goliath (>= 0) ruby depends on
      http_parser.rb (0.6.0.beta.2)
```
