### PR TITLE
Clenaup GOLIATH_ENV on new connections.

### DIFF
--- a/lib/goliath/connection.rb
+++ b/lib/goliath/connection.rb
@@ -19,6 +19,7 @@ module Goliath
       @current = nil
       @requests = []
       @pending  = []
+      Thread.current[GOLIATH_ENV] = nil
 
       @parser = Http::Parser.new
       @parser.on_headers_complete = proc do |h|


### PR DESCRIPTION
I have a websocket server using [faye-websocket](https://github.com/faye/faye-websocket-ruby) with Goliath. When a request arrives, and after reading all headers, Goliath [sets GOLIATH_ENV](https://github.com/postrank-labs/goliath/blob/master/lib/goliath/connection.rb#L18). Then faye [uses that var](https://github.com/faye/faye-websocket-ruby/blob/master/lib/faye/adapters/goliath.rb#L11) (indirectly, through `api.websocket?`) to figure out whether this is a websocket connection or not.

If that connection is then closed and a second request arrives in two parts, where the first part does not contain all headers, faye will use the old GOLIATH_ENV, because headers were not recceived yet, so the new GOLIATH_ENV was not set(remember it is set only when all headers are received), and this will cause faye to think that this is a websocket package, when in fact it isn't.

I'm running into this with ssl enabled and firefox. It seems each firefox requests arrives in two parts. First connection works ok, because GOLIATH_ENV was never set, so everything works as expected. If I close the connection and start it again, as the first package is incomplete and GOLIATH_ENV still has the old headers, faye thinks this is a websocket connection, which is wrong.

Simply initializing GOLIATH_ENV to nil during `post_init` solves the problem.
