### PR TITLE
Remove GOLIATH_ENV thread local from connection setup,

### DIFF
--- a/lib/goliath/connection.rb
+++ b/lib/goliath/connection.rb
@@ -22,7 +22,7 @@ module Goliath
 
       @parser = Http::Parser.new
       @parser.on_headers_complete = proc do |h|
-        env = Thread.current[GOLIATH_ENV] = Goliath::Env.new
+        env = Goliath::Env.new
         env[SERVER_PORT] = port.to_s
         env[RACK_LOGGER] = logger
         env[OPTIONS]     = options


### PR DESCRIPTION
There is no need to set it here, as it's set later in API class.

See also https://github.com/postrank-labs/goliath/pull/279
