### PR TITLE
catch bad uri error so the server does not crash

### DIFF
--- a/lib/goliath/request.rb
+++ b/lib/goliath/request.rb
@@ -102,7 +102,7 @@ module Goliath
         yield if block_given?
 
         @env[ASYNC_HEADERS].call(@env, h) if @env[ASYNC_HEADERS]
-      rescue Exception => e
+      rescue StandardError, Exception => e
         server_exception(e)
       end
     end

--- a/lib/goliath/version.rb
+++ b/lib/goliath/version.rb
@@ -1,4 +1,4 @@
 module Goliath
   # The current version of Goliath
-  VERSION = '1.0.3'
+  VERSION = '1.0.4'
 end


### PR DESCRIPTION
This patch prevents the server from crashing in case the uri parsing fails.
