### PR TITLE
Add missed line of code to examples/api_proxy.rb

### DIFF
--- a/examples/api_proxy.rb
+++ b/examples/api_proxy.rb
@@ -2,6 +2,8 @@
 
 # Rewrites and proxies requests to a third-party API, with HTTP basic authentication.
 
+$:<< '../lib' << 'lib'
+
 require 'goliath'
 require 'em-synchrony/em-http'
 


### PR DESCRIPTION
Example `examples/api_proxy.rb` does not work if `lib` is not in load path (`$:`). Fixed it.
