### PR TITLE
Use logger inside the stop method avoiding mutex from trap context

### DIFF
--- a/lib/goliath/server.rb
+++ b/lib/goliath/server.rb
@@ -107,7 +107,10 @@ module Goliath
 
     # Stops the server running.
     def stop
-      EM.stop
+      EM.add_timer(0) do
+        logger.info('Stopping server...')
+        EM.stop
+      end
     end
 
     # Loads a configuration file


### PR DESCRIPTION
In #271 the log statement in `Server#stop` was removed to avoid the `'lock': can't be called from trap context (ThreadError)` message appearing on Ruby 2, as it seemed that the only workaround was spawning a thread.

As per eventmachine/eventmachine#418 it turns out that there is another alternative: calling `add_timer(0)` from the trap context.

I think it can be useful to maintain the log message if this workaround seems right.
