### PR TITLE
Correctly suffix stdout logfile name with 'stdout' string.

### DIFF
--- a/lib/goliath/runner.rb
+++ b/lib/goliath/runner.rb
@@ -211,7 +211,8 @@ module Goliath
 
           File.umask(0000)
 
-          stdout_log_file = "#{File.dirname(@log_file)}/#{File.basename(@log_file)}_stdout.log"
+          log_extension = File.extname(@log_file)
+          stdout_log_file = "#{File.dirname(@log_file)}/#{File.basename(@log_file, log_extension)}_stdout#{log_extension}"
 
           STDIN.reopen("/dev/null")
           STDOUT.reopen(stdout_log_file, "a")


### PR DESCRIPTION
If I start goliath with:

`$ ruby myapp.rb -l mylog.log -dsv`

I expect the stdout logfile to be named `mylog_stdout.log`, and not `mylog.log_stdout.log`, which is the current behaviour.

This PR correctly handles logfile extension to get the stdout file named as expected.
