### PR TITLE
fix problem with Content-Length header

### DIFF
--- a/lib/goliath/rack/jsonp.rb
+++ b/lib/goliath/rack/jsonp.rb
@@ -17,7 +17,11 @@ module Goliath
         else
           response = body
         end
-
+        
+        callback_length = env.params['callback'].size
+        fixed_content_length = headers['Content-Length'].to_i + callback_length + 2
+        headers['Content-Length'] = fixed_content_length.to_s
+        
         headers[Goliath::Constants::CONTENT_TYPE] = 'application/javascript'
         [status, headers, ["#{env.params['callback']}(#{response})"]]
       end


### PR DESCRIPTION
I found that content length is too short so the response body is simply trimmed. This is a quick hack that allows me to go forward with my app. Feel free to improve.
