### PR TITLE
Add Ruby 2.2.0 to the travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
+  - 2.2.0
 #  - jruby-19mode
 script: bundle exec rake test
 notifications:


### PR DESCRIPTION
Seems to pass on my local box, fingers crossed :)

(I guess I could remove 1.9.2 at some point as well)