### PR TITLE
Add test_helper_sse to make it easier to test event streams.

### DIFF
--- a/goliath.gemspec
+++ b/goliath.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'multipart_body'
   s.add_development_dependency 'amqp', '>=0.7.1'
   s.add_development_dependency 'em-websocket-client'
+  s.add_development_dependency 'em-eventsource'
 
   s.add_development_dependency 'tilt', '>=1.2.2'
   s.add_development_dependency 'haml', '>=3.0.25'

--- a/lib/goliath/test_helper_sse.rb
+++ b/lib/goliath/test_helper_sse.rb
@@ -1,0 +1,66 @@
+require 'em-eventsource'
+
+module Goliath
+  module TestHelper
+    class SSEHelper
+      attr_reader :connection
+      def initialize(url)
+        @message_queue = []
+        @named_queues = {}
+        @connection = EM::EventSource.new(url)
+      end
+
+      def listen
+        @connection.message do |message|
+          @message_queue.push(message)
+        end
+      end
+
+      def listen_to(name)
+        queue = (@named_queues[name] ||= [])
+        @connection.on(name) do |message|
+          queue.push(message)
+        end
+      end
+
+      def received
+        @message_queue.to_a
+      end
+
+      def received_on(name)
+        queue = @named_queues.fetch(name) do
+          raise ArgumentError, "You have to call listen_to('#{name}') first"
+        end
+        queue.to_a
+      end
+
+      def with_async_http
+        klass = EM::HttpConnection
+        if klass.instance_methods.include?(:aget)
+          begin
+            klass.send(:class_eval) do
+              alias :sget :get
+              alias :get :aget
+            end
+            yield if block_given?
+          ensure
+            klass.send(:class_eval) do
+              alias :get :sget
+              remove_method :sget
+            end
+          end
+        else
+          yield if block_given?
+        end
+      end
+    end
+
+    def sse_client_connect(path,&blk)
+      url = "http://localhost:#{@test_server_port}#{path}"
+      client = SSEHelper.new(url)
+      client.with_async_http { client.connection.start }
+      client.listen
+      blk.call(client) if blk
+    end
+  end
+end

--- a/spec/integration/event_stream_spec.rb
+++ b/spec/integration/event_stream_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+require File.join(File.dirname(__FILE__), '../../', 'lib/goliath/test_helper_sse')
+require File.join(File.dirname(__FILE__), '../../', 'lib/goliath')
+require File.join(File.dirname(__FILE__), '../../', 'lib/goliath/api')
+
+class EventStreamEndpoint < Goliath::API
+  def self.events
+    @events ||= EM::Queue.new
+  end
+
+  def response(env)
+    self.class.events.pop do |event|
+      payload = if event.key?(:name)
+        "event: #{event[:name]}\ndata: #{event[:data]}\n\n"
+      else
+        "data: #{event[:data]}\n\n"
+      end
+      env.stream_send(payload)
+    end
+    streaming_response(200, 'Content-Type' => 'text/event-stream')
+  end
+end
+
+describe 'EventStream' do
+  include Goliath::TestHelper
+
+  context 'named events' do
+    it 'should accept stream' do
+      with_api(EventStreamEndpoint, {:verbose => true, :log_stdout => true}) do |server|
+        sse_client_connect('/stream') do |client|
+          client.listen_to('custom_event')
+          EM.add_timer(0.1) do
+            EventStreamEndpoint.events.push(name: 'custom_event', data: 'content')
+          end
+          EM.add_timer(0.2) do
+            client.received_on('custom_event').should == ['content']
+            client.received.should == []
+            stop
+          end
+        end
+      end
+    end
+  end
+
+  context 'unnamed events' do
+    it 'should accept stream' do
+      with_api(EventStreamEndpoint, {:verbose => true, :log_stdout => true}) do |server|
+        sse_client_connect('/stream') do |client|
+          EM.add_timer(0.1) do
+            EventStreamEndpoint.events.push(data: 'content')
+          end
+          EM.add_timer(0.2) do
+            client.received.should == ['content']
+            stop
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/event_stream_spec.rb
+++ b/spec/integration/event_stream_spec.rb
@@ -29,14 +29,9 @@ describe 'EventStream' do
       with_api(EventStreamEndpoint, {:verbose => true, :log_stdout => true}) do |server|
         sse_client_connect('/stream') do |client|
           client.listen_to('custom_event')
-          EM.add_timer(0.1) do
-            EventStreamEndpoint.events.push(name: 'custom_event', data: 'content')
-          end
-          EM.add_timer(0.2) do
-            client.received_on('custom_event').should == ['content']
-            client.received.should == []
-            stop
-          end
+          EventStreamEndpoint.events.push(name: 'custom_event', data: 'content')
+          client.receive_on('custom_event').should == ['content']
+          client.receive.should == []
         end
       end
     end
@@ -46,13 +41,8 @@ describe 'EventStream' do
     it 'should accept stream' do
       with_api(EventStreamEndpoint, {:verbose => true, :log_stdout => true}) do |server|
         sse_client_connect('/stream') do |client|
-          EM.add_timer(0.1) do
-            EventStreamEndpoint.events.push(data: 'content')
-          end
-          EM.add_timer(0.2) do
-            client.received.should == ['content']
-            stop
-          end
+          EventStreamEndpoint.events.push(data: 'content')
+          client.receive.should == ['content']
         end
       end
     end


### PR DESCRIPTION
Hey,

As described in [https://github.com/postrank-labs/goliath/issues/308](https://github.com/postrank-labs/goliath/issues/308) testing event streams is tricky when using `goliath/test_helper`, because it requires `em-synchrony/em-http` which makes `EM::HttpRequest#get` synchronous.

To workaround this I have added `goliath/test_helper_sse`.