### PR TITLE
Make green build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: ruby
 rvm:
-  - 1.9.2
-  - 1.9.3
+  - 2.2.1
+  - 2.1.5
   - 2.0.0
-  - 2.2.0
-#  - jruby-19mode
+  - ruby-head
+matrix:
+  allow_failures:
+    - rvm: ruby-head
 script: bundle exec rake test
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -4,18 +4,19 @@
 
 Goliath is an open source version of the non-blocking (asynchronous) Ruby web server framework. It is a lightweight framework designed to meet the following goals: bare metal performance, Rack API and middleware support, simple configuration, fully asynchronous processing, and readable and maintainable code (read: no callbacks).
 
-The framework is powered by an EventMachine reactor, a high-performance HTTP parser and Ruby 1.9+ runtime. The one major advantage Goliath has over other asynchronous frameworks is the fact that by leveraging Ruby fibers introduced in Ruby 1.9+, it can untangle the complicated callback-based code into a format we are all familiar and comfortable with: linear execution, which leads to more maintainable and readable code.
+The framework is powered by an EventMachine reactor, a high-performance HTTP parser and Ruby 2.0+ runtime. The one major advantage Goliath has over other asynchronous frameworks is the fact that by leveraging Ruby fibers introduced in Ruby 1.9+, it can untangle the complicated callback-based code into a format we are all familiar and comfortable with: linear execution, which leads to more maintainable and readable code.
 
 Each HTTP request within Goliath is executed within its own Ruby fiber and all asynchronous I/O operations can transparently suspend and later resume the processing without requiring the developer to write any additional code. Both request processing and response processing can be done in fully asynchronous fashion: streaming uploads, firehose API's, request/response, websockets, and so on.
 
+
 ## Installation & Prerequisites
 
-* Install Ruby 1.9 (via RVM or natively)
+* Install Ruby 2.2 (via RVM or natively)
 
 ```bash
 $> gem install rvm
-$> rvm install 1.9.3
-$> rvm use 1.9.3
+$> rvm install 2.2
+$> rvm use 2.2
 ```
 
 * Install Goliath:

--- a/goliath.gemspec
+++ b/goliath.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary = 'Async framework for writing API servers'
   s.description = s.summary
 
-  s.required_ruby_version = '>=1.9.2'
+  s.required_ruby_version = '~> 2.0'
 
   s.add_dependency 'eventmachine', '>= 1.0.0.beta.4'
   s.add_dependency 'em-synchrony', '>= 1.0.0'

--- a/goliath.gemspec
+++ b/goliath.gemspec
@@ -46,6 +46,10 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'guard-rspec', '~> 3.1.0'
   s.add_development_dependency 'listen', '~> 1.3.1'
 
+  if RUBY_VERSION >= '2.2'
+    s.add_development_dependency 'test-unit', '~> 3.0'
+  end
+
   if RUBY_PLATFORM != 'java'
     s.add_development_dependency 'yajl-ruby'
     s.add_development_dependency 'bluecloth'

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -63,7 +63,7 @@ describe Goliath::Request do
 
     it 'handles bad request urls' do
       parser = double('parser').as_null_object
-      parser.stub(:request_url).and_return('/bad?param}')
+      URI.should_receive(:parse) { raise URI::InvalidURIError }
 
       @r.stub(:server_exception)
       @r.should_receive(:server_exception)


### PR DESCRIPTION
Changes:

1. change the unit test, in `ruby >= 2.2` the `URI#parse` does not raise an exception for invalid chars, just  escape them. See https://bugs.ruby-lang.org/issues/2542 for more info.
2. `test-unit` was removed from `stdlib` in ruby 2.2, see https://bugs.ruby-lang.org/issues/9711
3. ~~`bson 2.2.3` is the latest appropriate version for ruby 1.9.2. `bson >= 2.2.4` is locked on ruby 1.9.3+
(btw, maybe it's better to drop 1.9.2 support :innocent:)~~
4. change the ruby version dependency to `~> 2.0`