### PR TITLE
Update test environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: ruby
 rvm:
-  - 1.9.2
-  - 1.9.3
+  - 2.2.1
+  - 2.1.5
   - 2.0.0
-  - 2.2.0
-#  - jruby-19mode
+  - ruby-head
+matrix:
+  allow_failures:
+    - rvm: ruby-head
 script: bundle exec rake test
 notifications:
   email:

--- a/Guardfile
+++ b/Guardfile
@@ -1,7 +1,7 @@
 # A sample Guardfile
 # More info at https://github.com/guard/guard#readme
 
-guard 'rspec', :version => 2 do
+guard 'rspec', cmd: 'bundle exec rspec' do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/goliath/(.+)\.rb$})     { |m| "spec/unit/#{m[1]}_spec.rb" }
 end

--- a/README.md
+++ b/README.md
@@ -4,18 +4,19 @@
 
 Goliath is an open source version of the non-blocking (asynchronous) Ruby web server framework. It is a lightweight framework designed to meet the following goals: bare metal performance, Rack API and middleware support, simple configuration, fully asynchronous processing, and readable and maintainable code (read: no callbacks).
 
-The framework is powered by an EventMachine reactor, a high-performance HTTP parser and Ruby 1.9+ runtime. The one major advantage Goliath has over other asynchronous frameworks is the fact that by leveraging Ruby fibers introduced in Ruby 1.9+, it can untangle the complicated callback-based code into a format we are all familiar and comfortable with: linear execution, which leads to more maintainable and readable code.
+The framework is powered by an EventMachine reactor, a high-performance HTTP parser and Ruby 2.0+ runtime. The one major advantage Goliath has over other asynchronous frameworks is the fact that by leveraging Ruby fibers introduced in Ruby 1.9+, it can untangle the complicated callback-based code into a format we are all familiar and comfortable with: linear execution, which leads to more maintainable and readable code.
 
 Each HTTP request within Goliath is executed within its own Ruby fiber and all asynchronous I/O operations can transparently suspend and later resume the processing without requiring the developer to write any additional code. Both request processing and response processing can be done in fully asynchronous fashion: streaming uploads, firehose API's, request/response, websockets, and so on.
 
+
 ## Installation & Prerequisites
 
-* Install Ruby 1.9 (via RVM or natively)
+* Install Ruby 2.2 (via RVM or natively)
 
 ```bash
 $> gem install rvm
-$> rvm install 1.9.3
-$> rvm use 1.9.3
+$> rvm install 2.2
+$> rvm use 2.2
 ```
 
 * Install Goliath:

--- a/goliath.gemspec
+++ b/goliath.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary = 'Async framework for writing API servers'
   s.description = s.summary
 
-  s.required_ruby_version = '>=1.9.2'
+  s.required_ruby_version = '~> 2.0'
 
   s.add_dependency 'eventmachine', '>= 1.0.0.beta.4'
   s.add_dependency 'em-synchrony', '>= 1.0.0'

--- a/goliath.gemspec
+++ b/goliath.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'multi_json'
 
   s.add_development_dependency 'rake', '>=0.8.7'
-  s.add_development_dependency 'rspec', '>2.0'
+  s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'nokogiri'
   s.add_development_dependency 'em-http-request', '>=1.0.0'
   s.add_development_dependency 'em-mongo', '~> 0.4.0'
@@ -42,9 +42,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'haml', '>=3.0.25'
   s.add_development_dependency 'yard'
 
-  s.add_development_dependency 'guard', '~> 1.8.3'
-  s.add_development_dependency 'guard-rspec', '~> 3.1.0'
-  s.add_development_dependency 'listen', '~> 1.3.1'
+  s.add_development_dependency 'guard-rspec', '~> 4.5'
 
   if RUBY_VERSION >= '2.2'
     s.add_development_dependency 'test-unit', '~> 3.0'

--- a/goliath.gemspec
+++ b/goliath.gemspec
@@ -46,6 +46,10 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'guard-rspec', '~> 3.1.0'
   s.add_development_dependency 'listen', '~> 1.3.1'
 
+  if RUBY_VERSION >= '2.2'
+    s.add_development_dependency 'test-unit', '~> 3.0'
+  end
+
   if RUBY_PLATFORM != 'java'
     s.add_development_dependency 'yajl-ruby'
     s.add_development_dependency 'bluecloth'

--- a/spec/integration/async_request_processing.rb
+++ b/spec/integration/async_request_processing.rb
@@ -13,8 +13,8 @@ describe 'Async Request processing' do
 
       post_request(request_data, err) do |c|
         resp = MultiJson.load(c.response)
-        resp['body'].should match('some=data')
-        resp['head'].should include('X-Upload')
+        expect(resp['body']).to match('some=data')
+        expect(resp['head']).to include('X-Upload')
       end
     end
   end

--- a/spec/integration/chunked_streaming_spec.rb
+++ b/spec/integration/chunked_streaming_spec.rb
@@ -27,7 +27,7 @@ describe "ChunkedStreaming" do
   it "should stream content" do
     with_api(ChunkedStreaming, {:verbose => true, :log_stdout => true}) do |server|
       streaming_client_connect('/streaming') do |client|
-        client.receive.should == "chunked"
+        expect(client.receive).to eq("chunked")
       end
     end
   end

--- a/spec/integration/early_abort_spec.rb
+++ b/spec/integration/early_abort_spec.rb
@@ -11,7 +11,7 @@ describe EarlyAbort do
   it "should return OK" do
     with_api(EarlyAbort) do
       get_request({}, err) do |c|
-        c.response.should == "OK"
+        expect(c.response).to eq("OK")
       end
     end
   end
@@ -24,8 +24,8 @@ describe EarlyAbort do
       }
 
       post_request(request_data, err) do |c|
-        c.response.should == "{\"error\":\"Can't handle requests with X-Crash: true.\"}"
-        File.exist?("/tmp/goliath-test-error.log").should be_false
+        expect(c.response).to eq("{\"error\":\"Can't handle requests with X-Crash: true.\"}")
+        expect(File.exist?("/tmp/goliath-test-error.log")).to be_falsey
       end
     end
   end
@@ -35,8 +35,8 @@ describe EarlyAbort do
       request_data = { :body => "a" * 20 }
 
       post_request(request_data, err) do |c|
-        c.response.should =~ /Payload size can't exceed 10 bytes/
-        File.exist?("/tmp/goliath-test-error.log").should be_false
+        expect(c.response).to match(/Payload size can't exceed 10 bytes/)
+        expect(File.exist?("/tmp/goliath-test-error.log")).to be_falsey
       end
     end
   end

--- a/spec/integration/echo_spec.rb
+++ b/spec/integration/echo_spec.rb
@@ -10,7 +10,7 @@ describe Echo do
     with_api(Echo) do
       get_request({:query => {:echo => 'test'}}, err) do |c|
         b = MultiJson.load(c.response)
-        b['response'].should == 'test'
+        expect(b['response']).to eq('test')
       end
     end
   end
@@ -19,8 +19,8 @@ describe Echo do
     with_api(Echo) do
       get_request({}, err) do |c|
         b = MultiJson.load(c.response)
-        b['error'].should_not be_nil
-        b['error'].should == 'echo identifier missing'
+        expect(b['error']).not_to be_nil
+        expect(b['error']).to eq('echo identifier missing')
       end
     end
   end
@@ -29,7 +29,7 @@ describe Echo do
     with_api(Echo) do
       post_request({:body => {'echo' => 'test'}}, err) do |c|
         b = MultiJson.load(c.response)
-        b['response'].should == 'test'
+        expect(b['response']).to eq('test')
       end
     end
   end
@@ -42,7 +42,7 @@ describe Echo do
       post_request({:body => body.to_s,
                     :head => head}, err) do |c|
         b = MultiJson.load(c.response)
-        b['response'].should == 'test'
+        expect(b['response']).to eq('test')
       end
     end
   end
@@ -55,7 +55,7 @@ describe Echo do
       post_request({:body => body.to_s,
                     :head => head}, err) do |c|
         b = MultiJson.load(c.response)
-        b['response'].should == 'My Echo'
+        expect(b['response']).to eq('My Echo')
       end
     end
   end
@@ -64,7 +64,7 @@ describe Echo do
     with_api(Echo) do
       patch_request({:body => {'echo' => 'test'}}, err) do |c|
         b = MultiJson.load(c.response)
-        b['response'].should == 'test'
+        expect(b['response']).to eq('test')
       end
     end
   end

--- a/spec/integration/empty_body_spec.rb
+++ b/spec/integration/empty_body_spec.rb
@@ -12,8 +12,8 @@ describe 'Empty body API' do
   it 'serves a 201 with no body' do
     with_api(Empty) do
       get_request({}, err) do |c|
-        c.response_header.status.should == 201
-        c.response_header['CONTENT_LENGTH'].should == '0'
+        expect(c.response_header.status).to eq(201)
+        expect(c.response_header['CONTENT_LENGTH']).to eq('0')
       end
     end
   end

--- a/spec/integration/event_stream_spec.rb
+++ b/spec/integration/event_stream_spec.rb
@@ -30,8 +30,8 @@ describe 'EventStream' do
         sse_client_connect('/stream') do |client|
           client.listen_to('custom_event')
           EventStreamEndpoint.events.push(name: 'custom_event', data: 'content')
-          client.receive_on('custom_event').should == ['content']
-          client.receive.should == []
+          expect(client.receive_on('custom_event')).to eq(['content'])
+          expect(client.receive).to eq([])
         end
       end
     end
@@ -42,7 +42,7 @@ describe 'EventStream' do
       with_api(EventStreamEndpoint, {:verbose => true, :log_stdout => true}) do |server|
         sse_client_connect('/stream') do |client|
           EventStreamEndpoint.events.push(data: 'content')
-          client.receive.should == ['content']
+          expect(client.receive).to eq(['content'])
         end
       end
     end

--- a/spec/integration/http_log_spec.rb
+++ b/spec/integration/http_log_spec.rb
@@ -42,7 +42,7 @@ describe HttpLog do
       mock_mongo(api)
 
       get_request({}, err) do |c|
-        c.response_header.status.should == 200
+        expect(c.response_header.status).to eq(200)
       end
     end
   end
@@ -53,9 +53,9 @@ describe HttpLog do
       mock_mongo(api)
 
       get_request({}, err) do |c|
-        c.response_header.status.should == 200
-        c.response_header['SPECIAL'].should == 'Header'
-        c.response.should == 'Hello from Responder'
+        expect(c.response_header.status).to eq(200)
+        expect(c.response_header['SPECIAL']).to eq('Header')
+        expect(c.response).to eq('Hello from Responder')
       end
     end
   end
@@ -63,8 +63,8 @@ describe HttpLog do
   context 'HTTP header handling' do
     it 'transforms back properly' do
       hl = HttpLog.new
-      hl.to_http_header("SPECIAL").should == 'Special'
-      hl.to_http_header("CONTENT_TYPE").should == 'Content-Type'
+      expect(hl.to_http_header("SPECIAL")).to eq('Special')
+      expect(hl.to_http_header("CONTENT_TYPE")).to eq('Content-Type')
     end
   end
 
@@ -75,8 +75,8 @@ describe HttpLog do
         mock_mongo(api)
 
         get_request({:query => {:first => :foo, :second => :bar, :third => :baz}}, err) do |c|
-          c.response_header.status.should == 200
-          c.response_header["PARAMS"].should == "first: foo|second: bar|third: baz"
+          expect(c.response_header.status).to eq(200)
+          expect(c.response_header["PARAMS"]).to eq("first: foo|second: bar|third: baz")
         end
       end
     end
@@ -89,8 +89,8 @@ describe HttpLog do
         mock_mongo(api)
 
         get_request({:path => '/my/request/path'}, err) do |c|
-          c.response_header.status.should == 200
-          c.response_header['PATH'].should == '/my/request/path'
+          expect(c.response_header.status).to eq(200)
+          expect(c.response_header['PATH']).to eq('/my/request/path')
         end
       end
     end
@@ -103,8 +103,8 @@ describe HttpLog do
         mock_mongo(api)
 
         get_request({:head => {:first => :foo, :second => :bar}}, err) do |c|
-          c.response_header.status.should == 200
-          c.response_header["HEADERS"].should =~ /First: foo\|Second: bar/
+          expect(c.response_header.status).to eq(200)
+          expect(c.response_header["HEADERS"]).to match(/First: foo\|Second: bar/)
         end
       end
     end
@@ -117,8 +117,8 @@ describe HttpLog do
         mock_mongo(api)
 
         get_request({}, err) do |c|
-          c.response_header.status.should == 200
-          c.response_header["METHOD"].should == "GET"
+          expect(c.response_header.status).to eq(200)
+          expect(c.response_header["METHOD"]).to eq("GET")
         end
       end
     end
@@ -129,8 +129,8 @@ describe HttpLog do
         mock_mongo(api)
 
         post_request({}, err) do |c|
-          c.response_header.status.should == 200
-          c.response_header["METHOD"].should == "POST"
+          expect(c.response_header.status).to eq(200)
+          expect(c.response_header["METHOD"]).to eq("POST")
         end
       end
     end

--- a/spec/integration/jsonp_spec.rb
+++ b/spec/integration/jsonp_spec.rb
@@ -30,7 +30,7 @@ describe 'JSONP' do
     it 'does not alter the content type' do
       with_api(JSON_API) do
         get_request({ query: query }, err) do |c|
-          c.response_header['CONTENT_TYPE'].should =~ %r{^application/json}
+          expect(c.response_header['CONTENT_TYPE']).to match(%r{^application/json})
         end
       end
     end
@@ -38,7 +38,7 @@ describe 'JSONP' do
     it 'does not alter the content length' do
       with_api(JSON_API) do
         get_request({ query: query }, err) do |c|
-          c.response_header['CONTENT_LENGTH'].to_i.should == 2
+          expect(c.response_header['CONTENT_LENGTH'].to_i).to eq(2)
         end
       end
     end
@@ -46,7 +46,7 @@ describe 'JSONP' do
     it 'does not wrap the response with anything' do
       with_api(JSON_API) do
         get_request({ query: query }, err) do |c|
-          c.response.should == 'OK'
+          expect(c.response).to eq('OK')
         end
       end
     end
@@ -58,7 +58,7 @@ describe 'JSONP' do
     it 'adjusts the content type' do
       with_api(JSON_API) do
         get_request({ query: query }, err) do |c|
-          c.response_header['CONTENT_TYPE'].should =~ %r{^application/javascript}
+          expect(c.response_header['CONTENT_TYPE']).to match(%r{^application/javascript})
         end
       end
     end
@@ -66,7 +66,7 @@ describe 'JSONP' do
     it 'adjusts the content length' do
       with_api(JSON_API) do
         get_request({ query: query }, err) do |c|
-          c.response_header['CONTENT_LENGTH'].to_i.should == 8
+          expect(c.response_header['CONTENT_LENGTH'].to_i).to eq(8)
         end
       end
     end
@@ -74,7 +74,7 @@ describe 'JSONP' do
     it 'wraps response with callback' do
       with_api(JSON_API) do
         get_request({ query: query }, err) do |c|
-          c.response.should =~ /^test\(.*\)$/
+          expect(c.response).to match(/^test\(.*\)$/)
         end
       end
     end

--- a/spec/integration/keepalive_spec.rb
+++ b/spec/integration/keepalive_spec.rb
@@ -10,13 +10,13 @@ describe 'HTTP Keep-Alive support' do
       r1.errback { fail }
       r1.callback do |c|
         b = MultiJson.load(c.response)
-        b['response'].should == 'test'
+        expect(b['response']).to eq('test')
 
         r2 = conn.get(:query => {:echo => 'test2'})
         r2.errback { fail }
         r2.callback do |c|
           b = MultiJson.load(c.response)
-          b['response'].should == 'test2'
+          expect(b['response']).to eq('test2')
 
           stop
         end

--- a/spec/integration/pipelining_spec.rb
+++ b/spec/integration/pipelining_spec.rb
@@ -24,15 +24,15 @@ describe 'HTTP Pipelining support' do
       r1.errback { fail }
       r1.callback do |c|
         res << c.response
-        c.response.should match('0.3')
+        expect(c.response).to match('0.3')
       end
 
       r2.errback { fail }
       r2.callback do |c|
         res << c.response
 
-        res.should == ['0.3', '0.2']
-        (Time.now.to_f - start).should be_within(0.1).of(0.3)
+        expect(res).to eq(['0.3', '0.2'])
+        expect(Time.now.to_f - start).to be_within(0.1).of(0.3)
 
         stop
       end

--- a/spec/integration/reloader_spec.rb
+++ b/spec/integration/reloader_spec.rb
@@ -29,15 +29,15 @@ describe "Reloader" do
   end
 
   it 'adds reloader in dev mode' do
-    count(ReloaderDev).should == 1
+    expect(count(ReloaderDev)).to eq(1)
   end
 
   it "doesn't add if it's already there in dev mode" do
-    count(ReloaderAlreadyLoaded).should == 1
+    expect(count(ReloaderAlreadyLoaded)).to eq(1)
   end
 
   it "doesn't add in prod mode" do
     Goliath.env = :production
-    count(ReloaderProd).should == 0
+    expect(count(ReloaderProd)).to eq(0)
   end
 end

--- a/spec/integration/template_spec.rb
+++ b/spec/integration/template_spec.rb
@@ -11,7 +11,7 @@ describe Template do
   it 'renders haml template with default haml layout' do
     with_api(Template, api_options) do
       get_request(:path => '/') do |c|
-        c.response.should =~ %r{<li><a href="/joke">Tell me a joke</a></li>}
+        expect(c.response).to match(%r{<li><a href="/joke">Tell me a joke</a></li>})
       end
     end
   end
@@ -19,7 +19,7 @@ describe Template do
   it 'renders haml template from string with default haml layout' do
     with_api(Template, api_options) do
       get_request(:path => '/haml_str') do |c|
-        c.response.should =~ %r{<h1>Header</h1>}
+        expect(c.response).to match(%r{<h1>Header</h1>})
       end
     end
   end
@@ -27,7 +27,7 @@ describe Template do
   it 'renders a markdown template with default haml layout' do
     with_api(Template, api_options) do
       get_request(:path => '/joke') do |c|
-        c.response.should =~ %r{<code>Arr, I dunno matey -- but it is driving me nuts!\s*</code>}m
+        expect(c.response).to match(%r{<code>Arr, I dunno matey -- but it is driving me nuts!\s*</code>}m)
       end
     end
   end
@@ -35,7 +35,7 @@ describe Template do
   it 'lets me specify an alternate layout engine' do
     with_api(Template, api_options) do
       get_request(:path => '/erb_me') do |c|
-        c.response.should =~ %r{I AM ERB</h1>}m
+        expect(c.response).to match(%r{I AM ERB</h1>}m)
       end
     end
   end
@@ -43,7 +43,7 @@ describe Template do
   it 'accepts local variables' do
     with_api(Template, api_options) do
       get_request(:path => '/erb_me') do |c|
-        c.response.should =~ %r{<title>HERE IS A JOKE</title>}m
+        expect(c.response).to match(%r{<title>HERE IS A JOKE</title>}m)
       end
     end
   end
@@ -52,8 +52,8 @@ describe Template do
     it 'raises an explanatory 500 error' do
       with_api(Template, api_options) do
         get_request(:path => '/oops') do |c|
-          c.response.should =~ %r{^\[:error, "Template no_such_template not found in .*examples/views for haml"\]$}
-          c.response_header.status.should == 500
+          expect(c.response).to match(%r{^\[:error, "Template no_such_template not found in .*examples/views for haml"\]$})
+          expect(c.response_header.status).to eq(500)
         end
       end
     end

--- a/spec/integration/test_helper_spec.rb
+++ b/spec/integration/test_helper_spec.rb
@@ -11,20 +11,20 @@ describe "with_api" do
     with_api(DummyServer, :log_file => "test.log") do |api|
       get_request({},err)
     end
-    File.exist?("test.log").should be_true
+    expect(File.exist?("test.log")).to be_truthy
     File.unlink("test.log")
   end
 
   it "should log on console if requested" do
     with_api(DummyServer, {:log_stdout => true }) do |api|
-      api.logger.outputters.select {|o| o.is_a? Log4r::StdoutOutputter}.should_not be_empty
+      expect(api.logger.outputters.select {|o| o.is_a? Log4r::StdoutOutputter}).not_to be_empty
       EM.stop
     end
   end
 
   it "should be verbose if asked" do
     with_api(DummyServer, {:verbose => true, :log_stdout => true }) do |api|
-      api.logger.level.should == Log4r::DEBUG
+      expect(api.logger.level).to eq(Log4r::DEBUG)
       EM.stop
     end
 

--- a/spec/integration/trace_spec.rb
+++ b/spec/integration/trace_spec.rb
@@ -8,7 +8,7 @@ describe Goliath::Rack::Tracer do
   it 'injects a trace param on a 200 (via async callback)' do
     with_api(Echo) do
       get_request({:query => {:echo => 'test'}}, err) do |c|
-        c.response_header['X_POSTRANK'].should =~ /trace\.start: [\d\.]+, total: [\d\.]+/
+        expect(c.response_header['X_POSTRANK']).to match(/trace\.start: [\d\.]+, total: [\d\.]+/)
       end
     end
   end
@@ -16,7 +16,7 @@ describe Goliath::Rack::Tracer do
   it 'injects a trace param on a 400 (direct callback)' do
     with_api(Echo) do
       get_request({}, err) do |c|
-        c.response_header['X_POSTRANK'].should =~ /trace\.start: [\d\.]+, total: [\d\.]+/
+        expect(c.response_header['X_POSTRANK']).to match(/trace\.start: [\d\.]+, total: [\d\.]+/)
       end
     end
   end

--- a/spec/integration/valid_spec.rb
+++ b/spec/integration/valid_spec.rb
@@ -38,7 +38,7 @@ describe ValidSingleParam do
   it 'returns OK with param' do
     with_api(ValidSingleParam) do
       get_request({:query => {:test => 'test'}}, err) do |c|
-        c.response.should == 'OK'
+        expect(c.response).to eq('OK')
       end
     end
   end
@@ -46,7 +46,7 @@ describe ValidSingleParam do
   it 'returns error without param' do
     with_api(ValidSingleParam) do
       get_request({}, err) do |c|
-        c.response.should == '[:error, "test identifier missing"]'
+        expect(c.response).to eq('[:error, "test identifier missing"]')
       end
     end
   end
@@ -64,8 +64,8 @@ describe ValidationErrorInEndpoint do
   it 'handles Goliath::Validation::Error correctly' do
     with_api(ValidationErrorInEndpoint) do
       get_request({}, err) do |c|
-        c.response.should == '[:error, "You Must Chill"]'
-        c.response_header.status.should == 420
+        expect(c.response).to eq('[:error, "You Must Chill"]')
+        expect(c.response_header.status).to eq(420)
       end
     end
   end

--- a/spec/integration/websocket_spec.rb
+++ b/spec/integration/websocket_spec.rb
@@ -26,7 +26,7 @@ describe "WebSocket" do
 
   it "should accept connection" do
     with_api(WebSocketEndPoint, {:verbose => true, :log_stdout => true}) do |server|
-      WebSocketEndPoint.any_instance.should_receive(:on_open)
+      expect_any_instance_of(WebSocketEndPoint).to receive(:on_open)
       ws_client_connect('/ws')
     end
   end
@@ -35,7 +35,7 @@ describe "WebSocket" do
     with_api(WebSocketEndPoint, {:verbose => true, :log_stdout => true}) do |server|
       ws_client_connect('/ws') do |client|
         client.send "hello"
-        client.receive.data.should == "hello"
+        expect(client.receive.data).to eq("hello")
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,5 @@ require 'goliath/test_helper'
 Goliath.env = :test
 
 RSpec.configure do |c|
-  c.include Goliath::TestHelper, :example_group => {
-    :file_path => /spec\/integration/
-  }
+  c.include Goliath::TestHelper, file_path: /spec\/integration/
 end

--- a/spec/unit/api_spec.rb
+++ b/spec/unit/api_spec.rb
@@ -7,7 +7,7 @@ describe Goliath::API do
 
   describe "middlewares" do
     it "doesn't change after multi calls" do
-      2.times { DummyApi.should have(2).middlewares }
+      2.times { expect(DummyApi.middlewares.size).to eq(2) }
     end
   end
 end

--- a/spec/unit/connection_spec.rb
+++ b/spec/unit/connection_spec.rb
@@ -9,39 +9,39 @@ describe Goliath::Connection do
     it 'accepts an app' do
       app = double('app')
       @c.app = app
-      @c.app.should == app
+      expect(@c.app).to eq(app)
     end
 
     it 'accepts a logger' do
       logger = double('logger')
       @c.logger = logger
-      @c.logger.should == logger
+      expect(@c.logger).to eq(logger)
     end
 
     it 'accepts a status object' do
       status = double('status')
       @c.status = status
-      @c.status.should == status
+      expect(@c.status).to eq(status)
     end
 
     it 'accepts config' do
       config = double('config')
       @c.config = config
-      @c.config.should == config
+      expect(@c.config).to eq(config)
     end
   end
 
   describe 'post_init' do
     it 'sets up the parser' do
       @c.post_init
-      @c.instance_variable_get("@parser").should_not be_nil
+      expect(@c.instance_variable_get("@parser")).not_to be_nil
     end
   end
 
   describe 'receive_data' do
     it 'passes data to the http parser' do
       request_mock = double("parser").as_null_object
-      request_mock.should_receive(:<<)
+      expect(request_mock).to receive(:<<)
 
       current_mock = double("current").as_null_object
 
@@ -52,10 +52,10 @@ describe Goliath::Connection do
 
     it "closes the connection when a parse error is received" do
       current_mock = double("current").as_null_object
-      current_mock.should_receive(:close)
+      expect(current_mock).to receive(:close)
 
       @c.instance_variable_set("@current", current_mock)
-      lambda { @c.receive_data("bad data") }.should_not raise_error
+      expect { @c.receive_data("bad data") }.not_to raise_error
     end
   end
 

--- a/spec/unit/console_spec.rb
+++ b/spec/unit/console_spec.rb
@@ -9,9 +9,9 @@ describe Goliath::Console do
 
   describe 'run!' do
     it "starts a irb session" do
-      Object.should_receive(:send).with(:define_method, :goliath_server)
-      IRB.should_receive(:start)
-      @server.should_receive(:load_config)
+      expect(Object).to receive(:send).with(:define_method, :goliath_server)
+      expect(IRB).to receive(:start)
+      expect(@server).to receive(:load_config)
       Goliath::Console.run!(@server)
     end
   end

--- a/spec/unit/env_spec.rb
+++ b/spec/unit/env_spec.rb
@@ -7,49 +7,49 @@ describe Goliath::Env do
   end
 
   it 'responds to []=' do
-    lambda { @env['test'] = 'blah' }.should_not raise_error
+    expect { @env['test'] = 'blah' }.not_to raise_error
   end
 
   it 'responds to []' do
     @env['test'] = 'blah'
-    lambda { @env['test'].should == 'blah' }.should_not raise_error
+    expect { expect(@env['test']).to eq('blah') }.not_to raise_error
   end
 
   context '#method_missing' do
     it 'allows access to items as methods' do
       @env['db'] = 'test'
-      @env.db.should == 'test'
+      expect(@env.db).to eq('test')
     end
 
     it 'allows access to config items as methods' do
       @env['config'] = {}
       @env['config']['db'] = 'test'
-      @env.db.should == 'test'
+      expect(@env.db).to eq('test')
     end
   end
 
   context '#respond_to?' do
     it 'returns true for items in the hash' do
       @env['test'] = 'true'
-      @env.respond_to?(:test).should be_true
+      expect(@env.respond_to?(:test)).to be_truthy
     end
 
     it 'returns false for items not in hash' do
-      @env.respond_to?(:test).should be_false
+      expect(@env.respond_to?(:test)).to be_falsey
     end
 
     it 'returns true for items in the config hash' do
       @env['config'] = {'test' => true}
-      @env.respond_to?(:test).should be_true
+      expect(@env.respond_to?(:test)).to be_truthy
     end
 
     it 'returns false for items not in the config hash' do
       @env['config'] = {}
-      @env.respond_to?(:test).should be_false
+      expect(@env.respond_to?(:test)).to be_falsey
     end
 
     it 'delegates if not found' do
-      @env.respond_to?(:[]).should be_true
+      expect(@env.respond_to?(:[])).to be_truthy
     end
   end
 end

--- a/spec/unit/headers_spec.rb
+++ b/spec/unit/headers_spec.rb
@@ -8,46 +8,46 @@ describe Goliath::Headers do
 
   it 'outputs in the correct format' do
     @h['my_header'] = 'my_value'
-    @h.to_s.should == "my_header: my_value\r\n"
+    expect(@h.to_s).to eq("my_header: my_value\r\n")
   end
 
   it 'suppresses duplicate keys' do
     @h['my_header'] = 'my_value1'
     @h['my_header'] = 'my_value2'
-    @h.to_s.should == "my_header: my_value1\r\n"
+    expect(@h.to_s).to eq("my_header: my_value1\r\n")
   end
 
   it 'returns true if a key has been set' do
     @h['my_header'] = 'my_value'
-    @h.has_key?('my_header').should be_true
+    expect(@h.has_key?('my_header')).to be_truthy
   end
 
   it 'returns false if the key has not been set' do
-    @h.has_key?('my_header').should be_false
+    expect(@h.has_key?('my_header')).to be_falsey
   end
 
   it 'ignores nil values' do
     @h['my_header'] = nil
-    @h.to_s.should == ''
+    expect(@h.to_s).to eq('')
   end
 
   it 'allows a value after setting nil' do
     @h['my_header'] = nil
     @h['my_header'] = 'my_value'
-    @h.to_s.should == "my_header: my_value\r\n"
+    expect(@h.to_s).to eq("my_header: my_value\r\n")
   end
 
   it 'formats time as an http time' do
     time = Time.now
     @h['my_time'] = time
-    @h.to_s.should == "my_time: #{time.httpdate}\r\n"
+    expect(@h.to_s).to eq("my_time: #{time.httpdate}\r\n")
   end
 
   %w(Set-Cookie Set-Cookie2 Warning WWW-Authenticate).each do |key|
     it "allows #{key} as to be duplicate" do
       @h[key] = 'value1'
       @h[key] = 'value2'
-      @h.to_s.should == "#{key}: value1\r\n#{key}: value2\r\n"
+      expect(@h.to_s).to eq("#{key}: value1\r\n#{key}: value2\r\n")
     end
   end
 end

--- a/spec/unit/rack/default_mime_type_spec.rb
+++ b/spec/unit/rack/default_mime_type_spec.rb
@@ -14,21 +14,21 @@ describe Goliath::Rack::DefaultMimeType do
   context 'accept header cleanup' do
     it 'handles a nil header' do
       env['HTTP_ACCEPT'] = nil
-      lambda { dmt.call(env) }.should_not raise_error
+      expect { dmt.call(env) }.not_to raise_error
     end
 
     %w(gzip deflate compressed identity).each do |type|
       it "removes #{type} from the accept header" do
         env['HTTP_ACCEPT'] = "text/html, #{type}, text/javascript"
         dmt.call(env)
-        env['HTTP_ACCEPT'].should == 'text/html, text/javascript'
+        expect(env['HTTP_ACCEPT']).to eq('text/html, text/javascript')
       end
     end
 
     it 'sets to */* if all entries removed' do
       env['HTTP_ACCEPT'] = 'identity'
       dmt.call(env)
-      env['HTTP_ACCEPT'].should == '*/*'
+      expect(env['HTTP_ACCEPT']).to eq('*/*')
     end
   end
 end

--- a/spec/unit/rack/formatters/json_spec.rb
+++ b/spec/unit/rack/formatters/json_spec.rb
@@ -3,7 +3,7 @@ require 'goliath/rack/formatters/json'
 
 describe Goliath::Rack::Formatters::JSON do
   it 'accepts an app' do
-    lambda { Goliath::Rack::Formatters::JSON.new('my app') }.should_not raise_error
+    expect { Goliath::Rack::Formatters::JSON.new('my app') }.not_to raise_error
   end
 
   describe 'with a formatter' do
@@ -13,41 +13,41 @@ describe Goliath::Rack::Formatters::JSON do
     end
 
     it 'checks content type for application/json' do
-      @js.json_response?({'Content-Type' => 'application/json'}).should be_true
+      expect(@js.json_response?({'Content-Type' => 'application/json'})).to be_truthy
     end
 
     it 'returns false for non-applicaton/json types' do
-      @js.json_response?({'Content-Type' => 'application/xml'}).should be_false
+      expect(@js.json_response?({'Content-Type' => 'application/xml'})).to be_falsey
     end
 
     it 'calls the app with the provided environment' do
       env_mock = double('env').as_null_object
-      @app.should_receive(:call).with(env_mock).and_return([200, {}, {"a" => 1}])
+      expect(@app).to receive(:call).with(env_mock).and_return([200, {}, {"a" => 1}])
       @js.call(env_mock)
     end
 
     it 'formats the body into json if content-type is json' do
-      @app.should_receive(:call).and_return([200, {'Content-Type' => 'application/json'}, {:a => 1, :b => 2}])
+      expect(@app).to receive(:call).and_return([200, {'Content-Type' => 'application/json'}, {:a => 1, :b => 2}])
 
       status, header, body = @js.call({})
-      lambda { MultiJson.load(body.first)['a'].should == 1 }.should_not raise_error
+      expect { expect(MultiJson.load(body.first)['a']).to eq(1) }.not_to raise_error
     end
 
     it "doesn't format to json if the type is not application/json" do
-      @app.should_receive(:call).and_return([200, {'Content-Type' => 'application/xml'}, {:a => 1, :b => 2}])
+      expect(@app).to receive(:call).and_return([200, {'Content-Type' => 'application/xml'}, {:a => 1, :b => 2}])
 
-      MultiJson.should_not_receive(:dump)
+      expect(MultiJson).not_to receive(:dump)
       status, header, body = @js.call({})
-      body[:a].should == 1
+      expect(body[:a]).to eq(1)
     end
 
     it 'returns the status and headers' do
-      @app.should_receive(:call).and_return([200, {'Content-Type' => 'application/xml'}, {:a => 1, :b => 2}])
+      expect(@app).to receive(:call).and_return([200, {'Content-Type' => 'application/xml'}, {:a => 1, :b => 2}])
 
-      MultiJson.should_not_receive(:dump)
+      expect(MultiJson).not_to receive(:dump)
       status, header, body = @js.call({})
-      status.should == 200
-      header.should == {'Content-Type' => 'application/xml'}
+      expect(status).to eq(200)
+      expect(header).to eq({'Content-Type' => 'application/xml'})
     end
   end
 end

--- a/spec/unit/rack/formatters/plist_spec.rb
+++ b/spec/unit/rack/formatters/plist_spec.rb
@@ -17,7 +17,7 @@ describe Goliath::Rack::Formatters::PLIST do
   end
 
   it 'accepts an app' do
-    lambda { Goliath::Rack::Formatters::PLIST.new('my app') }.should_not raise_error
+    expect { Goliath::Rack::Formatters::PLIST.new('my app') }.not_to raise_error
   end
 
   describe 'with a formatter' do
@@ -27,23 +27,23 @@ describe Goliath::Rack::Formatters::PLIST do
     end
 
     it 'formats the body into plist if content-type is plist' do
-      @app.should_receive(:call).and_return([200, {'Content-Type' => 'application/x-plist'}, {:a => 1, :b => 2}])
+      expect(@app).to receive(:call).and_return([200, {'Content-Type' => 'application/x-plist'}, {:a => 1, :b => 2}])
 
       status, header, body = @m.call({})
-      body.should == ["plist: {:a=>1, :b=>2}"]
+      expect(body).to eq(["plist: {:a=>1, :b=>2}"])
     end
 
     it "doesn't format to plist if the type is not plist" do
-      @app.should_receive(:call).and_return([200, {'Content-Type' => 'application/xml'}, {:a => 1, :b => 2}])
+      expect(@app).to receive(:call).and_return([200, {'Content-Type' => 'application/xml'}, {:a => 1, :b => 2}])
       status, header, body = @m.call({})
-      status.should == 200
-      header.should == {'Content-Type' => 'application/xml'}
+      expect(status).to eq(200)
+      expect(header).to eq({'Content-Type' => 'application/xml'})
 
-      body[:a].should == 1
+      expect(body[:a]).to eq(1)
     end
 
     it 'returns the status and headers' do
-      @app.should_receive(:call).and_return([200, {'Content-Type' => 'application/xml'}, {:a => 1, :b => 2}])
+      expect(@app).to receive(:call).and_return([200, {'Content-Type' => 'application/xml'}, {:a => 1, :b => 2}])
 
       status, header, body = @m.call({})
     end

--- a/spec/unit/rack/formatters/xml_spec.rb
+++ b/spec/unit/rack/formatters/xml_spec.rb
@@ -4,7 +4,7 @@ require 'nokogiri'
 
 describe Goliath::Rack::Formatters::XML do
   it 'accepts an app' do
-    lambda { Goliath::Rack::Formatters::XML.new('my app') }.should_not raise_error
+    expect { Goliath::Rack::Formatters::XML.new('my app') }.not_to raise_error
   end
 
   describe 'with a formatter' do
@@ -14,52 +14,52 @@ describe Goliath::Rack::Formatters::XML do
     end
 
     it 'checks content type for application/xml' do
-      @xml.xml_response?({'Content-Type' => 'application/xml'}).should be_true
+      expect(@xml.xml_response?({'Content-Type' => 'application/xml'})).to be_truthy
     end
 
     it 'returns false for non-applicaton/xml types' do
-      @xml.xml_response?({'Content-Type' => 'application/json'}).should be_false
+      expect(@xml.xml_response?({'Content-Type' => 'application/json'})).to be_falsey
     end
 
     it 'calls the app with the provided environment' do
       env_mock = double('env').as_null_object
-      @app.should_receive(:call).with(env_mock).and_return([200, {}, {"a" => 1}])
+      expect(@app).to receive(:call).with(env_mock).and_return([200, {}, {"a" => 1}])
       @xml.call(env_mock)
     end
 
     it 'formats the body into xml if content-type is xml' do
-      @app.should_receive(:call).and_return([200, {'Content-Type' => 'application/xml'}, {:a => 1, :b => 2}])
+      expect(@app).to receive(:call).and_return([200, {'Content-Type' => 'application/xml'}, {:a => 1, :b => 2}])
 
       status, header, body = @xml.call({})
-      lambda { Nokogiri.parse(body.first).search('a').inner_text.should == '1' }.should_not raise_error
+      expect { expect(Nokogiri.parse(body.first).search('a').inner_text).to eq('1') }.not_to raise_error
     end
 
     it 'generates arrays correctly' do
-      @app.should_receive(:call).and_return([200, {'Content-Type' => 'application/xml'}, [1, 2]])
+      expect(@app).to receive(:call).and_return([200, {'Content-Type' => 'application/xml'}, [1, 2]])
 
       status, header, body = @xml.call({})
-      lambda {
+      expect {
         doc = Nokogiri.parse(body.first)
-        doc.search('item').first.inner_text.should == '1'
-        doc.search('item').last.inner_text.should == '2'
-      }.should_not raise_error
+        expect(doc.search('item').first.inner_text).to eq('1')
+        expect(doc.search('item').last.inner_text).to eq('2')
+      }.not_to raise_error
     end
 
     it "doesn't format to xml if the type is not application/xml" do
-      @app.should_receive(:call).and_return([200, {'Content-Type' => 'application/json'}, {:a => 1, :b => 2}])
+      expect(@app).to receive(:call).and_return([200, {'Content-Type' => 'application/json'}, {:a => 1, :b => 2}])
 
-      @xml.should_not_receive(:to_xml)
+      expect(@xml).not_to receive(:to_xml)
       status, header, body = @xml.call({})
-      body[:a].should == 1
+      expect(body[:a]).to eq(1)
     end
 
     it 'returns the status and headers' do
-      @app.should_receive(:call).and_return([200, {'Content-Type' => 'application/json'}, {:a => 1, :b => 2}])
+      expect(@app).to receive(:call).and_return([200, {'Content-Type' => 'application/json'}, {:a => 1, :b => 2}])
 
-      @xml.should_not_receive(:to_xml)
+      expect(@xml).not_to receive(:to_xml)
       status, header, body = @xml.call({})
-      status.should == 200
-      header.should == {'Content-Type' => 'application/json'}
+      expect(status).to eq(200)
+      expect(header).to eq({'Content-Type' => 'application/json'})
     end
   end
 end

--- a/spec/unit/rack/formatters/yaml_spec.rb
+++ b/spec/unit/rack/formatters/yaml_spec.rb
@@ -3,7 +3,7 @@ require 'goliath/rack/formatters/yaml'
 
 describe Goliath::Rack::Formatters::YAML do
   it 'accepts an app' do
-    lambda { Goliath::Rack::Formatters::YAML.new('my app') }.should_not raise_error
+    expect { Goliath::Rack::Formatters::YAML.new('my app') }.not_to raise_error
   end
 
   describe 'with a formatter' do
@@ -13,41 +13,41 @@ describe Goliath::Rack::Formatters::YAML do
     end
 
     it 'checks content type for text/yaml' do
-      @ym.yaml_response?({'Content-Type' => 'text/yaml'}).should be_true
+      expect(@ym.yaml_response?({'Content-Type' => 'text/yaml'})).to be_truthy
     end
 
     it 'returns false for non-applicaton/yaml types' do
-      @ym.yaml_response?({'Content-Type' => 'application/xml'}).should be_false
+      expect(@ym.yaml_response?({'Content-Type' => 'application/xml'})).to be_falsey
     end
 
     it 'calls the app with the provided environment' do
       env_mock = double('env').as_null_object
-      @app.should_receive(:call).with(env_mock).and_return([200, {}, {"a" => 1}])
+      expect(@app).to receive(:call).with(env_mock).and_return([200, {}, {"a" => 1}])
       @ym.call(env_mock)
     end
 
     it 'formats the body into yaml if content-type is yaml' do
-      @app.should_receive(:call).and_return([200, {'Content-Type' => 'text/yaml'}, {:a => 1, :b => 2}])
+      expect(@app).to receive(:call).and_return([200, {'Content-Type' => 'text/yaml'}, {:a => 1, :b => 2}])
 
       status, header, body = @ym.call({})
-      lambda { YAML.load(body.first)[:a].should == 1 }.should_not raise_error
+      expect { expect(YAML.load(body.first)[:a]).to eq(1) }.not_to raise_error
     end
 
     it "doesn't format to yaml if the type is not text/yaml" do
-      @app.should_receive(:call).and_return([200, {'Content-Type' => 'application/xml'}, {:a => 1, :b => 2}])
+      expect(@app).to receive(:call).and_return([200, {'Content-Type' => 'application/xml'}, {:a => 1, :b => 2}])
 
-      YAML.should_not_receive(:encode)
+      expect(YAML).not_to receive(:encode)
       status, header, body = @ym.call({})
-      body[:a].should == 1
+      expect(body[:a]).to eq(1)
     end
 
     it 'returns the status and headers' do
-      @app.should_receive(:call).and_return([200, {'Content-Type' => 'application/xml'}, {:a => 1, :b => 2}])
+      expect(@app).to receive(:call).and_return([200, {'Content-Type' => 'application/xml'}, {:a => 1, :b => 2}])
 
-      YAML.should_not_receive(:encode)
+      expect(YAML).not_to receive(:encode)
       status, header, body = @ym.call({})
-      status.should == 200
-      header.should == {'Content-Type' => 'application/xml'}
+      expect(status).to eq(200)
+      expect(header).to eq({'Content-Type' => 'application/xml'})
     end
   end
 end

--- a/spec/unit/rack/heartbeat_spec.rb
+++ b/spec/unit/rack/heartbeat_spec.rb
@@ -4,7 +4,7 @@ require 'goliath/env'
 
 describe Goliath::Rack::Heartbeat do
   it 'accepts an app' do
-    lambda { Goliath::Rack::Heartbeat.new('my app') }.should_not raise_error
+    expect { Goliath::Rack::Heartbeat.new('my app') }.not_to raise_error
   end
 
   describe 'with the middleware' do
@@ -16,54 +16,54 @@ describe Goliath::Rack::Heartbeat do
     end
 
     it 'allows /status as a path prefix' do
-      @app.should_receive(:call)
+      expect(@app).to receive(:call)
       @env['PATH_INFO'] = '/status_endpoint'
       @hb.call(@env)
     end
 
     it "doesn't call the app when request /status" do
-      @app.should_not_receive(:call)
+      expect(@app).not_to receive(:call)
       @env['PATH_INFO'] = '/status'
       @hb.call(@env)
     end
 
     it 'returns the status, headers and body from the app on non-/status' do
       @env['PATH_INFO'] = '/v1'
-      @app.should_receive(:call).and_return([200, {'a' => 'b'}, {'c' => 'd'}])
+      expect(@app).to receive(:call).and_return([200, {'a' => 'b'}, {'c' => 'd'}])
       status, headers, body = @hb.call(@env)
-      status.should == 200
-      headers.should == {'a' => 'b'}
-      body.should == {'c' => 'd'}
+      expect(status).to eq(200)
+      expect(headers).to eq({'a' => 'b'})
+      expect(body).to eq({'c' => 'd'})
     end
 
     it 'returns the correct status, headers and body on /status' do
       @env['PATH_INFO'] = '/status'
       status, headers, body = @hb.call(@env)
-      status.should == 200
-      headers.should == {}
-      body.should == 'OK'
+      expect(status).to eq(200)
+      expect(headers).to eq({})
+      expect(body).to eq('OK')
     end
 
     it 'allows path and response to be set using options' do
       @hb = Goliath::Rack::Heartbeat.new(@app, :path => '/isup', :response => [204, {}, nil])
       @env['PATH_INFO'] = '/isup'
       status, headers, body = @hb.call(@env)
-      status.should == 204
-      headers.should == {}
-      body.should == nil
+      expect(status).to eq(204)
+      expect(headers).to eq({})
+      expect(body).to eq(nil)
     end
 
     it 'does not log the request by default' do
       @env['PATH_INFO'] = '/status'
       @hb.call(@env)
-      @env[Goliath::Constants::RACK_LOGGER].should == Log4r::Logger.root
+      expect(@env[Goliath::Constants::RACK_LOGGER]).to eq(Log4r::Logger.root)
     end
 
     it 'logs the request only if asked' do
       @env['PATH_INFO'] = '/status'
       @hb = Goliath::Rack::Heartbeat.new(@app, :log => true)
       @hb.call(@env)
-      @env[Goliath::Constants::RACK_LOGGER].should_not == Log4r::Logger.root
+      expect(@env[Goliath::Constants::RACK_LOGGER]).not_to eq(Log4r::Logger.root)
     end
   end
 end

--- a/spec/unit/rack/params_spec.rb
+++ b/spec/unit/rack/params_spec.rb
@@ -3,7 +3,7 @@ require 'goliath/rack/params'
 
 describe Goliath::Rack::Params do
   it 'accepts an app' do
-    lambda { Goliath::Rack::Params.new('my app') }.should_not raise_error
+    expect { Goliath::Rack::Params.new('my app') }.not_to raise_error
   end
 
   describe 'with middleware' do
@@ -25,15 +25,15 @@ describe Goliath::Rack::Params do
       @env['QUERY_STRING'] = 'foo=bar&baz=bonkey'
 
       ret = @params.retrieve_params(@env)
-      ret['foo'].should == 'bar'
-      ret['baz'].should == 'bonkey'
+      expect(ret['foo']).to eq('bar')
+      expect(ret['baz']).to eq('bonkey')
     end
 
     it 'parses the nested query string' do
       @env['QUERY_STRING'] = 'foo[bar]=baz'
 
       ret = @params.retrieve_params(@env)
-      ret['foo'].should == {'bar' => 'baz'}
+      expect(ret['foo']).to eq({'bar' => 'baz'})
     end
 
     it 'parses the post body' do
@@ -42,18 +42,18 @@ describe Goliath::Rack::Params do
       @env['rack.input'].rewind
 
       ret = @params.retrieve_params(@env)
-      ret['foo'].should == 'bar'
-      ret['baz'].should == 'bonkey'
-      ret['zonk'].should == {'donk' => 'monk'}
+      expect(ret['foo']).to eq('bar')
+      expect(ret['baz']).to eq('bonkey')
+      expect(ret['zonk']).to eq({'donk' => 'monk'})
     end
 
     it 'parses arrays of data' do
       @env['QUERY_STRING'] = 'foo[]=bar&foo[]=baz&foo[]=foos'
 
       ret = @params.retrieve_params(@env)
-      ret['foo'].is_a?(Array).should be_true
-      ret['foo'].length.should == 3
-      ret['foo'].should == %w(bar baz foos)
+      expect(ret['foo'].is_a?(Array)).to be_truthy
+      expect(ret['foo'].length).to eq(3)
+      expect(ret['foo']).to eq(%w(bar baz foos))
     end
 
     it 'parses multipart data' do
@@ -73,8 +73,8 @@ Berry\r
       @env[Goliath::Constants::CONTENT_LENGTH] = @env['rack.input'].length
 
       ret = @params.retrieve_params(@env)
-      ret['submit-name'].should == 'Larry'
-      ret['submit-name-with-content'].should == 'Berry'
+      expect(ret['submit-name']).to eq('Larry')
+      expect(ret['submit-name-with-content']).to eq('Berry')
     end
 
     it 'combines query string and post body params' do
@@ -85,14 +85,14 @@ Berry\r
       @env['rack.input'].rewind
 
       ret = @params.retrieve_params(@env)
-      ret['baz'].should == 'bar'
-      ret['foos'].should == 'bonkey'
+      expect(ret['baz']).to eq('bar')
+      expect(ret['foos']).to eq('bonkey')
     end
 
     it 'handles empty query and post body' do
       ret = @params.retrieve_params(@env)
-      ret.is_a?(Hash).should be_true
-      ret.should be_empty
+      expect(ret.is_a?(Hash)).to be_truthy
+      expect(ret).to be_empty
     end
 
     it 'prefers post body over query string' do
@@ -103,15 +103,15 @@ Berry\r
       @env['rack.input'].rewind
 
       ret = @params.retrieve_params(@env)
-      ret['foo'].should == 'bar2'
-      ret['baz'].should == 'bonkey'
+      expect(ret['foo']).to eq('bar2')
+      expect(ret['baz']).to eq('bonkey')
     end
 
     it 'sets the params into the environment' do
-      @app.should_receive(:call).with do |app_env|
-        app_env.has_key?('params').should be_true
-        app_env['params']['a'].should == 'b'
-      end
+      expect(@app).to receive(:call).with(@env) { |app_env|
+        expect(app_env.has_key?('params')).to be_truthy
+        expect(app_env['params']['a']).to eq('b')
+      }
 
       @env['QUERY_STRING'] = "a=b"
       @params.call(@env)
@@ -120,12 +120,12 @@ Berry\r
     it 'returns status, headers and body from the app' do
       app_headers = {'Content-Type' => 'hash'}
       app_body = {:a => 1, :b => 2}
-      @app.should_receive(:call).and_return([200, app_headers, app_body])
+      expect(@app).to receive(:call).and_return([200, app_headers, app_body])
 
       status, headers, body = @params.call(@env)
-      status.should == 200
-      headers.should == app_headers
-      body.should == app_body
+      expect(status).to eq(200)
+      expect(headers).to eq(app_headers)
+      expect(body).to eq(app_body)
     end
 
     context 'content type' do
@@ -136,7 +136,7 @@ Berry\r
         @env['rack.input'].rewind
 
         ret = @params.retrieve_params(@env)
-        ret['foos'].should == 'bonkey'
+        expect(ret['foos']).to eq('bonkey')
       end
 
       it "parses json" do
@@ -146,7 +146,7 @@ Berry\r
         @env['rack.input'].rewind
 
         ret = @params.retrieve_params(@env)
-        ret['foo'].should == 'bar'
+        expect(ret['foo']).to eq('bar')
       end
 
       it "parses json that does not evaluate to a hash" do
@@ -156,7 +156,7 @@ Berry\r
         @env['rack.input'].rewind
 
         ret = @params.retrieve_params(@env)
-        ret['_json'].should == ['foo', 'bar']
+        expect(ret['_json']).to eq(['foo', 'bar'])
       end
 
       it "handles empty input gracefully on JSON" do
@@ -164,7 +164,7 @@ Berry\r
         @env['rack.input'] = StringIO.new
 
         ret = @params.retrieve_params(@env)
-        ret.should be_empty
+        expect(ret).to be_empty
       end
 
       it "raises a BadRequestError on invalid JSON" do
@@ -173,7 +173,7 @@ Berry\r
         @env['rack.input'] << %|{"foo":"bar" BORKEN}|
         @env['rack.input'].rewind
 
-        lambda{ @params.retrieve_params(@env) }.should raise_error(Goliath::Validation::BadRequestError)
+        expect{ @params.retrieve_params(@env) }.to raise_error(Goliath::Validation::BadRequestError)
       end
 
       it "doesn't parse unknown content types" do
@@ -183,7 +183,7 @@ Berry\r
         @env['rack.input'].rewind
 
         ret = @params.retrieve_params(@env)
-        ret.should == {}
+        expect(ret).to eq({})
       end
     end
   end

--- a/spec/unit/rack/render_spec.rb
+++ b/spec/unit/rack/render_spec.rb
@@ -13,31 +13,31 @@ describe Goliath::Rack::Render do
   let(:render) { Goliath::Rack::Render.new(app) }
 
   it 'accepts an app' do
-    lambda { Goliath::Rack::Render.new('my app') }.should_not raise_error
+    expect { Goliath::Rack::Render.new('my app') }.not_to raise_error
   end
 
   it 'returns the status, body and app headers' do
     app_body = {'c' => 'd'}
 
-    app.should_receive(:call).and_return([200, {'a' => 'b'}, app_body])
+    expect(app).to receive(:call).and_return([200, {'a' => 'b'}, app_body])
     status, headers, body = render.call(env)
 
-    status.should == 200
-    headers['a'].should == 'b'
-    body.should == app_body
+    expect(status).to eq(200)
+    expect(headers['a']).to eq('b')
+    expect(body).to eq(app_body)
   end
 
   describe 'Vary' do
     it 'adds Accept to provided Vary header' do
-      app.should_receive(:call).and_return([200, {'Vary' => 'Cookie'}, {}])
+      expect(app).to receive(:call).and_return([200, {'Vary' => 'Cookie'}, {}])
       status, headers, body = render.call(env)
-      headers['Vary'].should == 'Cookie,Accept'
+      expect(headers['Vary']).to eq('Cookie,Accept')
     end
 
     it 'sets Accept if there is no Vary header' do
-      app.should_receive(:call).and_return([200, {}, {}])
+      expect(app).to receive(:call).and_return([200, {}, {}])
       status, headers, body = render.call(env)
-      headers['Vary'].should == 'Accept'
+      expect(headers['Vary']).to eq('Accept')
     end
   end
 
@@ -51,7 +51,7 @@ describe Goliath::Rack::Render do
 
   describe 'Content-Type' do
     before(:each) do
-      app.should_receive(:call).and_return([200, {}, {}])
+      expect(app).to receive(:call).and_return([200, {}, {}])
     end
 
     describe 'from header' do
@@ -59,7 +59,7 @@ describe Goliath::Rack::Render do
         it "handles content type for #{type}" do
           env['HTTP_ACCEPT'] = type
           status, headers, body = render.call(env)
-          headers['Content-Type'].should =~ /^#{Regexp.escape(type)}/
+          expect(headers['Content-Type']).to match(/^#{Regexp.escape(type)}/)
         end
       end
     end
@@ -69,7 +69,7 @@ describe Goliath::Rack::Render do
         it "converts #{format} to #{content_type}" do
           env['params']['format'] = format
           status, headers, body = render.call(env)
-          headers['Content-Type'].should =~ /^#{Regexp.escape(content_type)}/
+          expect(headers['Content-Type']).to match(/^#{Regexp.escape(content_type)}/)
         end
       end
     end
@@ -78,14 +78,14 @@ describe Goliath::Rack::Render do
       env['HTTP_ACCEPT'] = 'application/xml'
       env['params']['format'] = 'json'
       status, headers, body = render.call(env)
-      headers['Content-Type'].should =~ %r{^application/json}
+      expect(headers['Content-Type']).to match(%r{^application/json})
     end
 
     describe 'charset' do
       it 'is set if not present' do
         env['params']['format'] = 'json'
         status, headers, body = render.call(env)
-        headers['Content-Type'].should =~ /; charset=utf-8$/
+        expect(headers['Content-Type']).to match(/; charset=utf-8$/)
       end
     end
   end

--- a/spec/unit/rack/validation/boolean_value_spec.rb
+++ b/spec/unit/rack/validation/boolean_value_spec.rb
@@ -14,32 +14,32 @@ describe Goliath::Rack::Validation::BooleanValue do
 
     it 'uses the default if the key is not present' do
       @bv.call(@env)
-      @env['params']['id'].should == true
+      expect(@env['params']['id']).to eq(true)
     end
 
     it 'uses the default if the key is nil' do
       @env['params']['id'] = nil
       @bv.call(@env)
-      @env['params']['id'].should == true
+      expect(@env['params']['id']).to eq(true)
     end
 
     it 'uses the default if the key is blank' do
       @env['params']['id'] = ""
       @bv.call(@env)
-      @env['params']['id'].should == true
+      expect(@env['params']['id']).to eq(true)
     end
 
     it 'a random value is false' do
       @env['params']['id'] = 'blarg'
       @bv.call(@env)
-      @env['params']['id'].should == false
+      expect(@env['params']['id']).to eq(false)
     end
 
     %w(t true TRUE T 1).each do |type|
       it "considers #{type} true" do
         @env['params']['id'] = type
         @bv.call(@env)
-        @env['params']['id'].should == true
+        expect(@env['params']['id']).to eq(true)
       end
     end
 
@@ -47,7 +47,7 @@ describe Goliath::Rack::Validation::BooleanValue do
       it "considers #{type} false" do
         @env['params']['id'] = type
         @bv.call(@env)
-        @env['params']['id'].should == false
+        expect(@env['params']['id']).to eq(false)
       end
     end
   end

--- a/spec/unit/rack/validation/default_params_spec.rb
+++ b/spec/unit/rack/validation/default_params_spec.rb
@@ -4,15 +4,15 @@ require 'goliath/rack/validation/default_params'
 describe Goliath::Rack::Validation::DefaultParams do
   it 'accepts an app' do
     opts = {:defaults => ['title'], :key => 'fields'}
-    lambda { Goliath::Rack::Validation::DefaultParams.new('my app', opts) }.should_not raise_error
+    expect { Goliath::Rack::Validation::DefaultParams.new('my app', opts) }.not_to raise_error
   end
 
   it 'requires defaults to be set' do
-    lambda { Goliath::Rack::Validation::DefaultParams.new('my app', {:key => 'test'}) }.should raise_error
+    expect { Goliath::Rack::Validation::DefaultParams.new('my app', {:key => 'test'}) }.to raise_error
   end
 
   it 'requires key to be set' do
-    lambda { Goliath::Rack::Validation::DefaultParams.new('my app', {:defaults => 'test'}) }.should raise_error
+    expect { Goliath::Rack::Validation::DefaultParams.new('my app', {:defaults => 'test'}) }.to raise_error
   end
 
   describe 'with middleware' do
@@ -25,47 +25,47 @@ describe Goliath::Rack::Validation::DefaultParams do
     it 'passes through provided key if set' do
       @env['params']['fl'] = ['pubdate', 'content']
       @rf.call(@env)
-      @env['params']['fl'].should == ['pubdate', 'content']
+      expect(@env['params']['fl']).to eq(['pubdate', 'content'])
     end
 
     it 'sets defaults if no key set' do
       @rf.call(@env)
-      @env['params']['fl'].should == ['title', 'link']
+      expect(@env['params']['fl']).to eq(['title', 'link'])
     end
 
     it 'sets defaults if no key set' do
       @env['params']['fl'] = nil
       @rf.call(@env)
-      @env['params']['fl'].should == ['title', 'link']
+      expect(@env['params']['fl']).to eq(['title', 'link'])
     end
 
     it 'sets defaults if no key is empty' do
       @env['params']['fl'] = []
       @rf.call(@env)
-      @env['params']['fl'].should == ['title', 'link']
+      expect(@env['params']['fl']).to eq(['title', 'link'])
     end
 
     it 'handles a single item' do
       @env['params']['fl'] = 'title'
       @rf.call(@env)
-      @env['params']['fl'].should == 'title'
+      expect(@env['params']['fl']).to eq('title')
     end
 
     it 'handles a blank string' do
       @env['params']['fl'] = ''
       @rf.call(@env)
-      @env['params']['fl'].should == ['title', 'link']
+      expect(@env['params']['fl']).to eq(['title', 'link'])
     end
 
     it 'returns the app status, headers and body' do
       app_headers = {'Content-Type' => 'asdf'}
       app_body = {'a' => 'b'}
-      @app.should_receive(:call).and_return([200, app_headers, app_body])
+      expect(@app).to receive(:call).and_return([200, app_headers, app_body])
 
       status, headers, body = @rf.call(@env)
-      status.should == 200
-      headers.should == app_headers
-      body.should == app_body
+      expect(status).to eq(200)
+      expect(headers).to eq(app_headers)
+      expect(body).to eq(app_body)
     end
   end
 end

--- a/spec/unit/rack/validation/numeric_range_spec.rb
+++ b/spec/unit/rack/validation/numeric_range_spec.rb
@@ -9,7 +9,7 @@ describe Goliath::Rack::Validation::NumericRange do
 
   it 'accepts options on create' do
     opts = { :min => 1, :key => 2 }
-    lambda { Goliath::Rack::Validation::NumericRange.new('my app', opts) }.should_not raise_error
+    expect { Goliath::Rack::Validation::NumericRange.new('my app', opts) }.not_to raise_error
   end
 
   describe 'with middleware' do
@@ -20,41 +20,41 @@ describe Goliath::Rack::Validation::NumericRange do
     it 'uses the default if value is less then min' do
       @env['params']['id'] = -10
       @nr.call(@env)
-      @env['params']['id'].should == 15
+      expect(@env['params']['id']).to eq(15)
     end
 
     it 'uses the default if value is greater then max' do
       @env['params']['id'] = 25
       @nr.call(@env)
-      @env['params']['id'].should == 15
+      expect(@env['params']['id']).to eq(15)
     end
 
     it 'uses the first value, if the value is an array' do
       @env['params']['id'] = [10, 11, 12]
       @nr.call(@env)
-      @env['params']['id'].should == 10
+      expect(@env['params']['id']).to eq(10)
     end
 
     it 'uses the default if value is not present' do
       @nr.call(@env)
-      @env['params']['id'].should == 15
+      expect(@env['params']['id']).to eq(15)
     end
 
     it 'uses the default if value is nil' do
       @env['params']['id'] = nil
       @nr.call(@env)
-      @env['params']['id'].should == 15
+      expect(@env['params']['id']).to eq(15)
     end
 
     it 'returns the app status, headers and body' do
       app_headers = {'Content-Type' => 'app'}
       app_body = {'b' => 'c'}
-      @app.should_receive(:call).and_return([200, app_headers, app_body])
+      expect(@app).to receive(:call).and_return([200, app_headers, app_body])
 
       status, headers, body = @nr.call(@env)
-      status.should == 200
-      headers.should == app_headers
-      body.should == app_body
+      expect(status).to eq(200)
+      expect(headers).to eq(app_headers)
+      expect(body).to eq(app_body)
     end
   end
 
@@ -62,42 +62,42 @@ describe Goliath::Rack::Validation::NumericRange do
     nr = Goliath::Rack::Validation::NumericRange.new(@app, {:key => 'id', :min => 1.1, :as => Float})
     @env['params']['id'] = 1.5
     nr.call(@env)
-    @env['params']['id'].should == 1.5
+    expect(@env['params']['id']).to eq(1.5)
   end
 
   it 'raises error if key is not set' do
-    lambda { Goliath::Rack::Validation::NumericRange.new('app', {:min => 5}) }.should raise_error
+    expect { Goliath::Rack::Validation::NumericRange.new('app', {:min => 5}) }.to raise_error
   end
 
   it 'raises error if neither min nor max set' do
-    lambda { Goliath::Rack::Validation::NumericRange.new('app', {:key => 5}) }.should raise_error
+    expect { Goliath::Rack::Validation::NumericRange.new('app', {:key => 5}) }.to raise_error
   end
 
   it 'uses min if default not set' do
     nr = Goliath::Rack::Validation::NumericRange.new(@app, {:key => 'id', :min => 5, :max => 10})
     @env['params']['id'] = 15
     nr.call(@env)
-    @env['params']['id'].should == 5
+    expect(@env['params']['id']).to eq(5)
   end
 
   it 'uses max if default and min not set' do
     nr = Goliath::Rack::Validation::NumericRange.new(@app, {:key => 'id', :max => 10})
     @env['params']['id'] = 15
     nr.call(@env)
-    @env['params']['id'].should == 10
+    expect(@env['params']['id']).to eq(10)
   end
 
   it "doesn't require min" do
     nr = Goliath::Rack::Validation::NumericRange.new(@app, {:key => 'id', :max => 10})
     @env['params']['id'] = 8
     nr.call(@env)
-    @env['params']['id'].should == 8
+    expect(@env['params']['id']).to eq(8)
   end
 
   it "doesn't require max" do
     nr = Goliath::Rack::Validation::NumericRange.new(@app, {:key => 'id', :min => 1})
     @env['params']['id'] = 15
     nr.call(@env)
-    @env['params']['id'].should == 15
+    expect(@env['params']['id']).to eq(15)
   end
 end

--- a/spec/unit/rack/validation/param_spec.rb
+++ b/spec/unit/rack/validation/param_spec.rb
@@ -8,39 +8,39 @@ describe Goliath::Rack::Validation::Param do
   end
 
   it "should not allow invalid options" do
-    lambda {
+    expect {
       Goliath::Rack::Validation::Param.new(@app, {:key => 'user', :as => Class.new})
-    }.should raise_error
+    }.to raise_error
   end
 
   it "raises if key is not supplied" do
-    lambda {
+    expect {
       Goliath::Rack::Validation::Param.new(@app)
-    }.should raise_error(Exception)
+    }.to raise_error(Exception)
   end
 
   it "uses a default value if optional is not supplied" do
     cv = Goliath::Rack::Validation::Param.new(@app, :key => 'key')
-    cv.optional.should be_false
+    expect(cv.optional).to be_falsey
   end
 
   it "should have default and message be optional" do
     cv = nil
-    lambda {
+    expect {
       cv = Goliath::Rack::Validation::Param.new(@app, {:key => 'flag',
           :as => Goliath::Rack::Types::Boolean})
-    }.should_not raise_error
+    }.not_to raise_error
 
-    cv.default.should be_nil
-    cv.message.should_not be_nil
+    expect(cv.default).to be_nil
+    expect(cv.message).not_to be_nil
   end
 
   it "should fail if given an invalid option" do
     cv = nil
-    lambda {
+    expect {
       cv = Goliath::Rack::Validation::Param.new(@app, {:key => 'flag',
           :as => Goliath::Rack::Types::Boolean, :animal => :monkey})
-    }.should raise_error
+    }.to raise_error
   end
 
   context "fetch_key" do
@@ -57,7 +57,7 @@ describe Goliath::Rack::Validation::Param do
           }
         }
       }
-      @cv.fetch_key(params).should == "mike"
+      expect(@cv.fetch_key(params)).to eq("mike")
     end
 
     it "should return nil given an incorrect params" do
@@ -68,7 +68,7 @@ describe Goliath::Rack::Validation::Param do
           }
         }
       }
-      @cv.fetch_key(params).should be_nil
+      expect(@cv.fetch_key(params)).to be_nil
     end
 
     it "should set value if given" do
@@ -79,8 +79,8 @@ describe Goliath::Rack::Validation::Param do
           }
         }
       }
-      @cv.fetch_key(params, "tim").should == "tim"
-      params['data']['credentials']['login'].should == "tim"
+      expect(@cv.fetch_key(params, "tim")).to eq("tim")
+      expect(params['data']['credentials']['login']).to eq("tim")
     end
   end
 
@@ -88,9 +88,9 @@ describe Goliath::Rack::Validation::Param do
 
     it 'defaults type and message' do
       @rp = Goliath::Rack::Validation::Param.new('app', :key => 'key')
-      @rp.type.should_not be_nil
-      @rp.type.should_not =~ /^\s*$/
-      @rp.message.should == 'identifier missing'
+      expect(@rp.type).not_to be_nil
+      expect(@rp.type).not_to match(/^\s*$/)
+      expect(@rp.message).to eq('identifier missing')
     end
 
 
@@ -103,76 +103,76 @@ describe Goliath::Rack::Validation::Param do
       end
 
       it 'stores type and key options' do
-        @rp.type.should == 'Monkey'
-        @rp.key.should == 'mk'
+        expect(@rp.type).to eq('Monkey')
+        expect(@rp.key).to eq('mk')
       end
 
       it 'calls validation_error with a custom message' do
-        @rp.should_receive(:validation_error).with(anything, 'Monkey is required')
+        expect(@rp).to receive(:validation_error).with(anything, 'Monkey is required')
         @rp.call(@env)
       end
 
       it 'returns the app status, headers and body' do
         app_headers = {'Content-Type' => 'app'}
         app_body = {'b' => 'c'}
-        @app.should_receive(:call).and_return([201, app_headers, app_body])
+        expect(@app).to receive(:call).and_return([201, app_headers, app_body])
 
         @env['params']['mk'] = 'monkey'
 
         status, headers, body = @rp.call(@env)
-        status.should == 201
-        headers.should == app_headers
-        body.should == app_body
+        expect(status).to eq(201)
+        expect(headers).to eq(app_headers)
+        expect(body).to eq(app_body)
       end
 
       context 'key_valid?' do
         it 'raises exception if the key is not provided' do
-          @rp.key_valid?(@env['params']).should be_false
+          expect(@rp.key_valid?(@env['params'])).to be_falsey
         end
 
         it 'raises exception if the key is blank' do
           @env['params']['mk'] = ''
-          @rp.key_valid?(@env['params']).should be_false
+          expect(@rp.key_valid?(@env['params'])).to be_falsey
         end
 
         it 'raises exception if the key is nil' do
           @env['params']['mk'] = nil
-          @rp.key_valid?(@env['params']).should be_false
+          expect(@rp.key_valid?(@env['params'])).to be_falsey
         end
 
         it 'handles an empty array' do
           @env['params']['mk'] = []
-          @rp.key_valid?(@env['params']).should be_false
+          expect(@rp.key_valid?(@env['params'])).to be_falsey
         end
 
         it 'handles an array of nils' do
           @env['params']['mk'] = [nil, nil, nil]
-          @rp.key_valid?(@env['params']).should be_false
+          expect(@rp.key_valid?(@env['params'])).to be_falsey
         end
 
         it 'handles an array of blanks' do
           @env['params']['mk'] = ['', '', '']
-          @rp.key_valid?(@env['params']).should be_false
+          expect(@rp.key_valid?(@env['params'])).to be_falsey
         end
 
         it "doesn't raise if the key provided" do
           @env['params']['mk'] = 'my value'
-          @rp.key_valid?(@env['params']).should be_true
+          expect(@rp.key_valid?(@env['params'])).to be_truthy
         end
 
         it "doesn't raise if the array contains valid data" do
           @env['params']['mk'] = [1, 2, 3, 4]
-          @rp.key_valid?(@env['params']).should be_true
+          expect(@rp.key_valid?(@env['params'])).to be_truthy
         end
 
         it "doesn't raise if the key provided is multiline and has blanks" do
           @env['params']['mk'] = "my\n  \nvalue"
-          @rp.key_valid?(@env['params']).should be_true
+          expect(@rp.key_valid?(@env['params'])).to be_truthy
         end
 
         it "doesn't raise if the key provided is an array and contains multiline with blanks" do
           @env['params']['mk'] = ["my\n  \nvalue", "my\n  \nother\n  \nvalue"]
-          @rp.key_valid?(@env['params']).should be_true
+          expect(@rp.key_valid?(@env['params'])).to be_truthy
         end
       end
     end
@@ -194,7 +194,7 @@ describe Goliath::Rack::Validation::Param do
         }
         }
 
-        @rp.key_valid?(@env['params']).should be_false
+        expect(@rp.key_valid?(@env['params'])).to be_falsey
       end
 
       it "return true if key is present" do
@@ -205,7 +205,7 @@ describe Goliath::Rack::Validation::Param do
         }
         }
 
-        @rp.key_valid?(@env['params']).should be_true
+        expect(@rp.key_valid?(@env['params'])).to be_truthy
       end
     end
 
@@ -225,7 +225,7 @@ describe Goliath::Rack::Validation::Param do
         }
         }
 
-        @rp.key_valid?(@env['params']).should be_false
+        expect(@rp.key_valid?(@env['params'])).to be_falsey
       end
 
       it "return true if key is present" do
@@ -236,7 +236,7 @@ describe Goliath::Rack::Validation::Param do
         }
         }
 
-        @rp.key_valid?(@env['params']).should be_true
+        expect(@rp.key_valid?(@env['params'])).to be_truthy
       end
     end
 
@@ -245,9 +245,9 @@ describe Goliath::Rack::Validation::Param do
   context "Coerce" do
 
     it "should only accept a class in the :as" do
-      lambda {
+      expect {
         Goliath::Rack::Validation::Param.new(@app, {:key => 'user', :as => "not a class"})
-      }.should raise_error
+      }.to raise_error
     end
 
     context 'with middleware' do
@@ -266,7 +266,7 @@ describe Goliath::Rack::Validation::Param do
             @env['params']['user'] = value.first
             cv = Goliath::Rack::Validation::Param.new(@app, {:key => 'user', :as => type})
             cv.call(@env)
-            @env['params']['user'].should == value[1]
+            expect(@env['params']['user']).to eq(value[1])
           end
         end
       end
@@ -282,9 +282,9 @@ describe Goliath::Rack::Validation::Param do
             @env['params']['user'] = value
             cv = Goliath::Rack::Validation::Param.new(@app, {:key => 'user', :as => type})
             result = cv.call(@env)
-            result.should be_an_instance_of(Array)
-            result.first.should == 400
-            result.last.should have_key(:error)
+            expect(result).to be_an_instance_of(Array)
+            expect(result.first).to eq(400)
+            expect(result.last).to have_key(:error)
           end
         end
       end
@@ -292,10 +292,10 @@ describe Goliath::Rack::Validation::Param do
       it "should not fail with a invalid input, given a default value" do
         cv = nil
         @env['params']['user'] = "boo"
-        lambda {
+        expect {
           cv = Goliath::Rack::Validation::Param.new(@app, {:key => 'user',
               :as => Goliath::Rack::Types::Boolean , :default => 'default'})
-        }.should_not raise_error
+        }.not_to raise_error
           @env['params']['user'] = 'default'
       end
 
@@ -305,10 +305,10 @@ describe Goliath::Rack::Validation::Param do
             :as => Goliath::Rack::Types::Integer, :message => "custom message"})
 
         result = cv.call(@env)
-        result.should be_an_instance_of(Array)
-        result.first.should == 400
-        result.last.should have_key(:error)
-        result.last[:error].should == "custom message"
+        expect(result).to be_an_instance_of(Array)
+        expect(result.first).to eq(400)
+        expect(result.last).to have_key(:error)
+        expect(result.last[:error]).to eq("custom message")
       end
     end
 
@@ -320,15 +320,15 @@ describe Goliath::Rack::Validation::Param do
           :as => Goliath::Rack::Types::Integer
       @env['params']['login'] = "3"
       cv.call(@env)
-      @env['params']['login'].should == 3
+      expect(@env['params']['login']).to eq(3)
 
       @env['params']['login'] = nil
       cv = Goliath::Rack::Validation::Param.new @app, :key => "login",
           :as => Goliath::Rack::Types::Integer
       result = cv.call(@env)
-      result.should be_an_instance_of(Array)
-      result.first.should == 400
-      result.last.should have_key(:error)
+      expect(result).to be_an_instance_of(Array)
+      expect(result.first).to eq(400)
+      expect(result.last).to have_key(:error)
     end
 
     it "should do required param + coerce (nested)" do
@@ -337,30 +337,30 @@ describe Goliath::Rack::Validation::Param do
       @env['params']['login'] = {}
       @env['params']['login']['other'] = "3"
       cv.call(@env)
-      @env['params']['login']['other'].should == 3
+      expect(@env['params']['login']['other']).to eq(3)
 
       @env['params']['login'] = {}
       @env['params']['login']['other'] = nil
       cv = Goliath::Rack::Validation::Param.new @app, :key => "login.other",
           :as => Goliath::Rack::Types::Integer
       result = cv.call(@env)
-      result.should be_an_instance_of(Array)
-      result.first.should == 400
-      result.last.should have_key(:error)
+      expect(result).to be_an_instance_of(Array)
+      expect(result.first).to eq(400)
+      expect(result.last).to have_key(:error)
     end
 
     it "should do required param + not coerce (not nested)" do
       cv = Goliath::Rack::Validation::Param.new @app, :key => "login"
       @env['params']['login'] = "3"
       cv.call(@env)
-      @env['params']['login'].should == "3"
+      expect(@env['params']['login']).to eq("3")
 
       @env['params']['login'] = nil
       cv = Goliath::Rack::Validation::Param.new @app, :key => "login"
       result = cv.call(@env)
-      result.should be_an_instance_of(Array)
-      result.first.should == 400
-      result.last.should have_key(:error)
+      expect(result).to be_an_instance_of(Array)
+      expect(result.first).to eq(400)
+      expect(result.last).to have_key(:error)
     end
 
     it "should do required param + not coerce (nested)" do
@@ -368,15 +368,15 @@ describe Goliath::Rack::Validation::Param do
       @env['params']['login'] = {}
       @env['params']['login']['other'] = "3"
       cv.call(@env)
-      @env['params']['login']['other'].should == "3"
+      expect(@env['params']['login']['other']).to eq("3")
 
       @env['params']['login'] = {}
       @env['params']['login']['other'] = nil
       cv = Goliath::Rack::Validation::Param.new @app, :key => "login.other"
       result = cv.call(@env)
-      result.should be_an_instance_of(Array)
-      result.first.should == 400
-      result.last.should have_key(:error)
+      expect(result).to be_an_instance_of(Array)
+      expect(result.first).to eq(400)
+      expect(result.last).to have_key(:error)
     end
 
     it "should do optional param + coerce (not nested)" do
@@ -384,13 +384,13 @@ describe Goliath::Rack::Validation::Param do
           :as => Goliath::Rack::Types::Integer, :optional => true
       @env['params']['login'] = "3"
       cv.call(@env)
-      @env['params']['login'].should == 3
+      expect(@env['params']['login']).to eq(3)
 
       @env['params']['login'] = nil
       cv = Goliath::Rack::Validation::Param.new @app, :key => "login",
           :as => Goliath::Rack::Types::Integer, :optional => true
       result = cv.call(@env)
-      result.should_not be_an_instance_of(Array) #implying its OK
+      expect(result).not_to be_an_instance_of(Array) #implying its OK
     end
 
     it "should do optional param + coerce (nested)" do
@@ -399,14 +399,14 @@ describe Goliath::Rack::Validation::Param do
       @env['params']['login'] = {}
       @env['params']['login']['other'] = "3"
       cv.call(@env)
-      @env['params']['login']['other'].should == 3
+      expect(@env['params']['login']['other']).to eq(3)
 
       @env['params']['login'] = {}
       @env['params']['login']['other'] = nil
       cv = Goliath::Rack::Validation::Param.new @app, :key => ['login', 'other'],
           :as => Goliath::Rack::Types::Integer, :optional => true
       result = cv.call(@env)
-      result.should_not be_an_instance_of(Array) #implying its OK
+      expect(result).not_to be_an_instance_of(Array) #implying its OK
     end
 
     it "should do optional param and not coerce (not nested)" do
@@ -414,13 +414,13 @@ describe Goliath::Rack::Validation::Param do
           :optional => true
       @env['params']['login'] = "3"
       cv.call(@env)
-      @env['params']['login'].should == "3"
+      expect(@env['params']['login']).to eq("3")
 
       @env['params']['login'] = nil
       cv = Goliath::Rack::Validation::Param.new @app, :key => "login",
           :optional => true
       result = cv.call(@env)
-      result.should_not be_an_instance_of(Array) #implying its OK
+      expect(result).not_to be_an_instance_of(Array) #implying its OK
     end
 
     it "should do optional param and not coerce (nested)" do
@@ -429,14 +429,14 @@ describe Goliath::Rack::Validation::Param do
       @env['params']['login'] = {}
       @env['params']['login']['other'] = "3"
       cv.call(@env)
-      @env['params']['login']['other'].should == "3"
+      expect(@env['params']['login']['other']).to eq("3")
 
       @env['params']['login'] = {}
       @env['params']['login']['other'] = nil
       cv = Goliath::Rack::Validation::Param.new @app, :key => "login.other",
           :optional => true
       result = cv.call(@env)
-      result.should_not be_an_instance_of(Array) #implying its OK
+      expect(result).not_to be_an_instance_of(Array) #implying its OK
     end
   end
 end

--- a/spec/unit/rack/validation/request_method_spec.rb
+++ b/spec/unit/rack/validation/request_method_spec.rb
@@ -7,11 +7,11 @@ describe Goliath::Rack::Validation::RequestMethod do
     @app_body = {'a' => 'b'}
 
     @app = double('app').as_null_object
-    @app.stub(:call).and_return([200, @app_headers, @app_body])
+    allow(@app).to receive(:call).and_return([200, @app_headers, @app_body])
   end
 
   it 'accepts an app' do
-    lambda { Goliath::Rack::Validation::RequestMethod.new('my app') }.should_not raise_error
+    expect { Goliath::Rack::Validation::RequestMethod.new('my app') }.not_to raise_error
   end
 
   describe 'with defaults' do
@@ -22,31 +22,31 @@ describe Goliath::Rack::Validation::RequestMethod do
 
     it 'raises error if method is invalid' do
       @env['REQUEST_METHOD'] = 'fubar'
-      @rm.call(@env).should == [405, {'Allow' => 'GET, POST'}, {:error => "Invalid request method"}]
+      expect(@rm.call(@env)).to eq([405, {'Allow' => 'GET, POST'}, {:error => "Invalid request method"}])
     end
 
     it 'allows valid methods through' do
       @env['REQUEST_METHOD'] = 'GET'
-      @rm.call(@env).should == [200, @app_headers, @app_body]
+      expect(@rm.call(@env)).to eq([200, @app_headers, @app_body])
     end
 
     it 'returns app status, headers and body' do
       @env['REQUEST_METHOD'] = 'POST'
 
       status, headers, body = @rm.call(@env)
-      status.should == 200
-      headers.should == @app_headers
-      body.should == @app_body
+      expect(status).to eq(200)
+      expect(headers).to eq(@app_headers)
+      expect(body).to eq(@app_body)
     end
   end
 
   it 'accepts methods on initialize' do
     rm = Goliath::Rack::Validation::RequestMethod.new('my app', ['GET', 'DELETE', 'HEAD'])
-    rm.methods.should == ['GET', 'DELETE', 'HEAD']
+    expect(rm.methods).to eq(['GET', 'DELETE', 'HEAD'])
   end
 
   it 'accepts string method on initialize' do
     rm = Goliath::Rack::Validation::RequestMethod.new('my app', 'GET')
-    rm.methods.should == ['GET']
+    expect(rm.methods).to eq(['GET'])
   end
 end

--- a/spec/unit/rack/validation/required_param_spec.rb
+++ b/spec/unit/rack/validation/required_param_spec.rb
@@ -3,23 +3,23 @@ require 'goliath/rack/validation/required_param'
 
 describe Goliath::Rack::Validation::RequiredParam do
   it 'accepts an app' do
-    lambda { Goliath::Rack::Validation::RequiredParam.new('my app') }.should_not raise_error
+    expect { Goliath::Rack::Validation::RequiredParam.new('my app') }.not_to raise_error
   end
 
   it 'accepts options on create' do
     opts = { :type => 1, :key => 2, :message => 'is required' }
-    lambda { Goliath::Rack::Validation::RequiredParam.new('my app', opts) }.should_not raise_error
+    expect { Goliath::Rack::Validation::RequiredParam.new('my app', opts) }.not_to raise_error
   end
 
   it 'defaults type, key and message' do
     @rp = Goliath::Rack::Validation::RequiredParam.new('app')
-    @rp.key.should_not be_nil
-    @rp.key.should_not =~ /^\s*$/
+    expect(@rp.key).not_to be_nil
+    expect(@rp.key).not_to match(/^\s*$/)
 
-    @rp.type.should_not be_nil
-    @rp.type.should_not =~ /^\s*$/
+    expect(@rp.type).not_to be_nil
+    expect(@rp.type).not_to match(/^\s*$/)
 
-    @rp.message.should == 'identifier missing'
+    expect(@rp.message).to eq('identifier missing')
   end
 
   describe 'with middleware' do
@@ -30,76 +30,76 @@ describe Goliath::Rack::Validation::RequiredParam do
     end
 
     it 'stores type and key options' do
-      @rp.type.should == 'Monkey'
-      @rp.key.should == 'mk'
+      expect(@rp.type).to eq('Monkey')
+      expect(@rp.key).to eq('mk')
     end
 
     it 'calls validation_error with a custom message' do
-      @rp.should_receive(:validation_error).with(anything, 'Monkey is required')
+      expect(@rp).to receive(:validation_error).with(anything, 'Monkey is required')
       @rp.call(@env)
     end
 
     it 'returns the app status, headers and body' do
       app_headers = {'Content-Type' => 'app'}
       app_body = {'b' => 'c'}
-      @app.should_receive(:call).and_return([201, app_headers, app_body])
+      expect(@app).to receive(:call).and_return([201, app_headers, app_body])
 
       @env['params']['mk'] = 'monkey'
 
       status, headers, body = @rp.call(@env)
-      status.should == 201
-      headers.should == app_headers
-      body.should == app_body
+      expect(status).to eq(201)
+      expect(headers).to eq(app_headers)
+      expect(body).to eq(app_body)
     end
 
     describe 'key_valid?' do
       it 'raises exception if the key is not provided' do
-        @rp.key_valid?(@env['params']).should be_false
+        expect(@rp.key_valid?(@env['params'])).to be_falsey
       end
 
       it 'raises exception if the key is blank' do
         @env['params']['mk'] = ''
-        @rp.key_valid?(@env['params']).should be_false
+        expect(@rp.key_valid?(@env['params'])).to be_falsey
       end
 
       it 'raises exception if the key is nil' do
         @env['params']['mk'] = nil
-        @rp.key_valid?(@env['params']).should be_false
+        expect(@rp.key_valid?(@env['params'])).to be_falsey
       end
 
       it 'handles an empty array' do
         @env['params']['mk'] = []
-        @rp.key_valid?(@env['params']).should be_false
+        expect(@rp.key_valid?(@env['params'])).to be_falsey
       end
 
       it 'handles an array of nils' do
         @env['params']['mk'] = [nil, nil, nil]
-        @rp.key_valid?(@env['params']).should be_false
+        expect(@rp.key_valid?(@env['params'])).to be_falsey
       end
 
       it 'handles an array of blanks' do
         @env['params']['mk'] = ['', '', '']
-        @rp.key_valid?(@env['params']).should be_false
+        expect(@rp.key_valid?(@env['params'])).to be_falsey
       end
 
       it "doesn't raise if the key provided" do
         @env['params']['mk'] = 'my value'
-        @rp.key_valid?(@env['params']).should be_true
+        expect(@rp.key_valid?(@env['params'])).to be_truthy
       end
 
       it "doesn't raise if the array contains valid data" do
         @env['params']['mk'] = [1, 2, 3, 4]
-        @rp.key_valid?(@env['params']).should be_true
+        expect(@rp.key_valid?(@env['params'])).to be_truthy
       end
 
       it "doesn't raise if the key provided is multiline and has blanks" do
         @env['params']['mk'] = "my\n  \nvalue"
-        @rp.key_valid?(@env['params']).should be_true
+        expect(@rp.key_valid?(@env['params'])).to be_truthy
       end
 
       it "doesn't raise if the key provided is an array and contains multiline with blanks" do
         @env['params']['mk'] = ["my\n  \nvalue", "my\n  \nother\n  \nvalue"]
-        @rp.key_valid?(@env['params']).should be_true
+        expect(@rp.key_valid?(@env['params'])).to be_truthy
       end      
     end
   end
@@ -123,7 +123,7 @@ describe Goliath::Rack::Validation::RequiredParam do
             }
         }
       
-      @rp.key_valid?(@env['params']).should be_false
+      expect(@rp.key_valid?(@env['params'])).to be_falsey
     end
     
     it "return true if key is present" do
@@ -134,7 +134,7 @@ describe Goliath::Rack::Validation::RequiredParam do
             }
         }
       
-      @rp.key_valid?(@env['params']).should be_true
+      expect(@rp.key_valid?(@env['params'])).to be_truthy
     end
   end
   
@@ -157,7 +157,7 @@ describe Goliath::Rack::Validation::RequiredParam do
             }
         }
       
-      @rp.key_valid?(@env['params']).should be_false
+      expect(@rp.key_valid?(@env['params'])).to be_falsey
     end
     
     it "return true if key is present" do
@@ -168,7 +168,7 @@ describe Goliath::Rack::Validation::RequiredParam do
             }
         }
       
-      @rp.key_valid?(@env['params']).should be_true
+      expect(@rp.key_valid?(@env['params'])).to be_truthy
     end
   end
   

--- a/spec/unit/rack/validation/required_value_spec.rb
+++ b/spec/unit/rack/validation/required_value_spec.rb
@@ -3,18 +3,18 @@ require 'goliath/rack/validation/required_value'
 
 describe Goliath::Rack::Validation::RequiredValue do
   it 'accepts an app' do
-    lambda { Goliath::Rack::Validation::RequiredValue.new('my app') }.should_not raise_error
+    expect { Goliath::Rack::Validation::RequiredValue.new('my app') }.not_to raise_error
   end
 
   it 'accepts options on create' do
     opts = { :key => 2, :values => ["foo", "bar"] }
-    lambda { Goliath::Rack::Validation::RequiredValue.new('my app', opts) }.should_not raise_error
+    expect { Goliath::Rack::Validation::RequiredValue.new('my app', opts) }.not_to raise_error
   end
 
 
   it 'turns a single option into an array' do
     rv = Goliath::Rack::Validation::RequiredValue.new('my app', :key => 2, :values => "foo")
-    rv.values.should == ['foo']
+    expect(rv.values).to eq(['foo'])
   end
 
   describe 'with middleware' do
@@ -25,71 +25,71 @@ describe Goliath::Rack::Validation::RequiredValue do
     end
 
     it 'stores type and key options' do
-      @rv.values.should == ['Monkey', 'frog']
-      @rv.key.should == 'mk'
+      expect(@rv.values).to eq(['Monkey', 'frog'])
+      expect(@rv.key).to eq('mk')
     end
 
     it 'returns the app status, headers and body' do
       app_headers = {'Content-Type' => 'app'}
       app_body = {'b' => 'c'}
-      @app.should_receive(:call).and_return([201, app_headers, app_body])
+      expect(@app).to receive(:call).and_return([201, app_headers, app_body])
 
       @env['params']['mk'] = 'Monkey'
 
       status, headers, body = @rv.call(@env)
-      status.should == 201
-      headers.should == app_headers
-      body.should == app_body
+      expect(status).to eq(201)
+      expect(headers).to eq(app_headers)
+      expect(body).to eq(app_body)
     end
 
     context '#value_valid!' do
       it 'raises exception if the key is not provided' do
-        @rv.value_valid?(@env['params']).should be_false
+        expect(@rv.value_valid?(@env['params'])).to be_falsey
       end
 
       it 'raises exception if the key is blank' do
         @env['params']['mk'] = ''
-        @rv.value_valid?(@env['params']).should be_false
+        expect(@rv.value_valid?(@env['params'])).to be_falsey
       end
 
       it 'raises exception if the key is nil' do
         @env['params']['mk'] = nil
-        @rv.value_valid?(@env['params']).should be_false
+        expect(@rv.value_valid?(@env['params'])).to be_falsey
       end
 
       it 'raises exception if the key is does not match' do
         @env['params']['mk'] = "blarg"
-        @rv.value_valid?(@env['params']).should be_false
+        expect(@rv.value_valid?(@env['params'])).to be_falsey
       end
 
       it 'handles an empty array' do
         @env['params']['mk'] = []
-        @rv.value_valid?(@env['params']).should be_false
+        expect(@rv.value_valid?(@env['params'])).to be_falsey
       end
 
       it 'handles an array of nils' do
         @env['params']['mk'] = [nil, nil, nil]
-        @rv.value_valid?(@env['params']).should be_false
+        expect(@rv.value_valid?(@env['params'])).to be_falsey
       end
 
       it 'handles an array of blanks' do
         @env['params']['mk'] = ['', '', '']
-        @rv.value_valid?(@env['params']).should be_false
+        expect(@rv.value_valid?(@env['params'])).to be_falsey
       end
 
       it "doesn't raise if the key is value" do
         @env['params']['mk'] = 'Monkey'
-        @rv.value_valid?(@env['params']).should be_true
+        expect(@rv.value_valid?(@env['params'])).to be_truthy
       end
 
       it "doesn't raise if the array contains valid data" do
         @env['params']['mk'] = ['Monkey', 'frog']
-        @rv.value_valid?(@env['params']).should be_true
+        expect(@rv.value_valid?(@env['params'])).to be_truthy
       end
 
       it 'raises if any of the array elements do not match' do
         @env['params']['mk'] = ["Monkey", "frog", "bat"]
-        @rv.value_valid?(@env['params']).should be_false
+        expect(@rv.value_valid?(@env['params'])).to be_falsey
       end
     end
   end

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -14,15 +14,15 @@ describe Goliath::Request do
       env['INIT'] = 'init'
 
       r = Goliath::Request.new(nil, nil, env)
-      r.env['INIT'].should == 'init'
+      expect(r.env['INIT']).to eq('init')
     end
 
     it 'initializes an async callback' do
-      @r.env['async.callback'].should_not be_nil
+      expect(@r.env['async.callback']).not_to be_nil
     end
 
     it 'initializes request' do
-      @r.instance_variable_get("@state").should == :processing
+      expect(@r.instance_variable_get("@state")).to eq(:processing)
     end
   end
 
@@ -32,8 +32,8 @@ describe Goliath::Request do
       env_mock = double('app').as_null_object
       request = Goliath::Request.new(app_mock, nil, env_mock)
 
-      app_mock.should_receive(:call).with(request.env)
-      request.should_receive(:post_process)
+      expect(app_mock).to receive(:call).with(request.env)
+      expect(request).to receive(:post_process)
 
       request.process
     end
@@ -41,50 +41,50 @@ describe Goliath::Request do
 
   describe 'finished?' do
     it "returns false if the request parsing has not yet finished" do
-      @r.finished?.should be_false
+      expect(@r.finished?).to be_falsey
     end
 
     it 'returns true if we have finished request parsing' do
-      @r.should_receive(:post_process).and_return(nil)
+      expect(@r).to receive(:post_process).and_return(nil)
       @r.process
 
-      @r.finished?.should be_true
+      expect(@r.finished?).to be_truthy
     end
   end
 
   describe 'parse_headers' do
     it 'sets content_type correctly' do
       parser = double('parser').as_null_object
-      parser.stub(:request_url).and_return('')
+      allow(parser).to receive(:request_url).and_return('')
 
       @r.parse_header({'Content-Type' => 'text/plain'}, parser)
-      @r.env['CONTENT_TYPE'].should == 'text/plain'
+      expect(@r.env['CONTENT_TYPE']).to eq('text/plain')
     end
 
     it 'handles bad request urls' do
       parser = double('parser').as_null_object
-      URI.should_receive(:parse) { raise URI::InvalidURIError }
+      expect(URI).to receive(:parse) { raise URI::InvalidURIError }
 
-      @r.stub(:server_exception)
-      @r.should_receive(:server_exception)
+      allow(@r).to receive(:server_exception)
+      expect(@r).to receive(:server_exception)
       @r.parse_header({}, parser)
     end
 
     it 'sets content_length correctly' do
       parser = double('parser').as_null_object
-      parser.stub(:request_url).and_return('')
+      allow(parser).to receive(:request_url).and_return('')
 
       @r.parse_header({'Content-Length' => 42}, parser)
-      @r.env['CONTENT_LENGTH'].should == 42
+      expect(@r.env['CONTENT_LENGTH']).to eq(42)
     end
 
     it 'sets server_name and server_port correctly' do
       parser = double('parser').as_null_object
-      parser.stub(:request_url).and_return('')
+      allow(parser).to receive(:request_url).and_return('')
 
       @r.parse_header({'Host' => 'myhost.com:3000'}, parser)
-      @r.env['SERVER_NAME'].should == 'myhost.com'
-      @r.env['SERVER_PORT'].should == '3000'
+      expect(@r.env['SERVER_NAME']).to eq('myhost.com')
+      expect(@r.env['SERVER_PORT']).to eq('3000')
     end
   end
 end

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -63,7 +63,7 @@ describe Goliath::Request do
 
     it 'handles bad request urls' do
       parser = double('parser').as_null_object
-      parser.stub(:request_url).and_return('/bad?param}')
+      URI.should_receive(:parse) { raise URI::InvalidURIError }
 
       @r.stub(:server_exception)
       @r.should_receive(:server_exception)

--- a/spec/unit/response_spec.rb
+++ b/spec/unit/response_spec.rb
@@ -8,28 +8,28 @@ describe Goliath::Response do
 
   it 'allows setting status' do
     @r.status = 400
-    @r.status.should == 400
+    expect(@r.status).to eq(400)
   end
 
   it 'allows setting headers' do
     @r.headers = [['my_key', 'my_headers']]
-    @r.headers.to_s.should == "my_key: my_headers\r\n"
+    expect(@r.headers.to_s).to eq("my_key: my_headers\r\n")
   end
 
   it 'allows setting body' do
     @r.body = 'my body'
-    @r.body.should == 'my body'
+    expect(@r.body).to eq('my body')
   end
 
   it 'sets a default status' do
-    @r.status.should == 200
+    expect(@r.status).to eq(200)
   end
 
   it 'sets default headers' do
-    @r.headers.should_not be_nil
+    expect(@r.headers).not_to be_nil
   end
 
   it 'outputs the http header' do
-    @r.head.should == "HTTP/1.1 200 OK\r\n"
+    expect(@r.head).to eq("HTTP/1.1 200 OK\r\n")
   end
 end

--- a/spec/unit/runner_spec.rb
+++ b/spec/unit/runner_spec.rb
@@ -4,23 +4,23 @@ require 'goliath/runner'
 describe Goliath::Runner do
   before(:each) do
     @r = Goliath::Runner.new([], nil)
-    @r.stub(:store_pid)
+    allow(@r).to receive(:store_pid)
 
     @log_mock = double('logger').as_null_object
-    @r.stub(:setup_logger).and_return(@log_mock)
+    allow(@r).to receive(:setup_logger).and_return(@log_mock)
   end
 
   describe 'server execution' do
     describe 'daemonization' do
       it 'daemonizes if specified' do
-        Process.should_receive(:fork)
+        expect(Process).to receive(:fork)
         @r.daemonize = true
         @r.run
       end
 
       it "doesn't daemonize if not specified" do
-        Process.should_not_receive(:fork)
-        @r.should_receive(:run_server)
+        expect(Process).not_to receive(:fork)
+        expect(@r).to receive(:run_server)
         @r.run
       end
     end
@@ -38,46 +38,46 @@ describe Goliath::Runner do
 
       describe 'without setting up file logger' do
         before(:each) do
-          @r.stub(:setup_file_logger)
+          allow(@r).to receive(:setup_file_logger)
         end
 
         it 'configures the logger' do
           log = @r.send(:setup_logger)
-          log.should_not be_nil
+          expect(log).not_to be_nil
         end
 
         [:debug, :warn, :info].each do |type|
           it "responds to #{type} messages" do
             log = @r.send(:setup_logger)
-            log.respond_to?(type).should be_true
+            expect(log.respond_to?(type)).to be_truthy
           end
         end
 
         describe 'log level' do
           before(:each) do
-            FileUtils.stub(:mkdir_p)
+            allow(FileUtils).to receive(:mkdir_p)
           end
 
           it 'sets the default log level' do
             log = @r.send(:setup_logger)
-            log.level.should == Log4r::INFO
+            expect(log.level).to eq(Log4r::INFO)
           end
 
           it 'sets debug when verbose' do
             @r.verbose = true
             log = @r.send(:setup_logger)
-            log.level.should == Log4r::DEBUG
+            expect(log.level).to eq(Log4r::DEBUG)
           end
         end
 
         describe 'file logger' do
           it "doesn't configure by default" do
-            @r.should_not_receive(:setup_file_logger)
+            expect(@r).not_to receive(:setup_file_logger)
             log = @r.send(:setup_logger)
           end
 
           it 'configures if -l is provided' do
-            @r.should_receive(:setup_file_logger)
+            expect(@r).to receive(:setup_file_logger)
             @r.log_file = 'out.log'
             log = @r.send(:setup_logger)
           end
@@ -85,12 +85,12 @@ describe Goliath::Runner do
 
         describe 'stdout logger' do
           it "doesn't configure by default" do
-            @r.should_not_receive(:setup_stdout_logger)
+            expect(@r).not_to receive(:setup_stdout_logger)
             log = @r.send(:setup_logger)
           end
 
           it 'configures if -s is provided' do
-            @r.should_receive(:setup_stdout_logger)
+            expect(@r).to receive(:setup_stdout_logger)
             @r.log_stdout = true
             log = @r.send(:setup_logger)
           end
@@ -100,7 +100,7 @@ describe Goliath::Runner do
 
           it "doesn't configure Log4r" do
             CustomLogger = Struct.new(:info, :debug, :error, :fatal)
-            Log4r::Logger.should_not_receive(:new)
+            expect(Log4r::Logger).not_to receive(:new)
             @r.logger = CustomLogger.new
             log = @r.send(:setup_logger)
           end
@@ -109,10 +109,10 @@ describe Goliath::Runner do
       end
 
       it 'creates the log dir if neeed' do
-        Log4r::FileOutputter.stub(:new)
+        allow(Log4r::FileOutputter).to receive(:new)
         log_mock = double('log').as_null_object
 
-        FileUtils.should_receive(:mkdir_p).with('/my/log/dir')
+        expect(FileUtils).to receive(:mkdir_p).with('/my/log/dir')
 
         @r.log_file = '/my/log/dir/log.txt'
         @r.send(:setup_file_logger, log_mock, nil)
@@ -121,34 +121,34 @@ describe Goliath::Runner do
 
     it 'sets up the api if that implements the #setup method' do
       server_mock = double("Server").as_null_object
-      server_mock.api.should_receive(:setup)
+      expect(server_mock.api).to receive(:setup)
 
-      Goliath::Server.stub(:new).and_return(server_mock)
+      allow(Goliath::Server).to receive(:new).and_return(server_mock)
 
-      @r.stub(:load_config).and_return({})
+      allow(@r).to receive(:load_config).and_return({})
       @r.send(:run_server)
     end
 
     it 'runs the server' do
       server_mock = double("Server").as_null_object
-      server_mock.should_receive(:start)
+      expect(server_mock).to receive(:start)
 
-      Goliath::Server.should_receive(:new).and_return(server_mock)
+      expect(Goliath::Server).to receive(:new).and_return(server_mock)
 
-      @r.stub(:load_config).and_return({})
+      allow(@r).to receive(:load_config).and_return({})
       @r.send(:run_server)
     end
 
     it 'configures the server' do
       server_mock = Goliath::Server.new
-      server_mock.stub(:start)
+      allow(server_mock).to receive(:start)
 
       @r.app = 'my_app'
 
-      Goliath::Server.should_receive(:new).and_return(server_mock)
+      expect(Goliath::Server).to receive(:new).and_return(server_mock)
 
-      server_mock.should_receive(:logger=).with(@log_mock)
-      server_mock.should_receive(:app=).with('my_app')
+      expect(server_mock).to receive(:logger=).with(@log_mock)
+      expect(server_mock).to receive(:app=).with('my_app')
 
       @r.send(:run_server)
     end
@@ -161,17 +161,17 @@ describe Goliath::EnvironmentParser do
   end
 
   it 'returns the default environment if no other options are set' do
-    Goliath::EnvironmentParser.parse.should == Goliath::DEFAULT_ENV
+    expect(Goliath::EnvironmentParser.parse).to eq(Goliath::DEFAULT_ENV)
   end
 
   it 'gives precendence to RACK_ENV over the default' do
     ENV['RACK_ENV'] = 'rack_env'
-    Goliath::EnvironmentParser.parse.should == :rack_env
+    expect(Goliath::EnvironmentParser.parse).to eq(:rack_env)
   end
 
   it 'gives precendence to command-line flag over RACK_ENV' do
     ENV['RACK_ENV'] = 'rack_env'
     args = %w{ -e flag_env }
-    Goliath::EnvironmentParser.parse(args).should == :flag_env
+    expect(Goliath::EnvironmentParser.parse(args)).to eq(:flag_env)
   end
 end

--- a/spec/unit/server_spec.rb
+++ b/spec/unit/server_spec.rb
@@ -8,50 +8,50 @@ describe Goliath::Server do
 
   describe 'defaults' do
     it 'to any interface' do
-      @s.address.should == '0.0.0.0'
+      expect(@s.address).to eq('0.0.0.0')
     end
 
     it 'to port 9000' do
-      @s.port.should == 9000
+      expect(@s.port).to eq(9000)
     end
   end
 
   describe 'configuration' do
     it 'accepts an address and port' do
       @s = Goliath::Server.new('10.2.1.1', 2020)
-      @s.address.should == '10.2.1.1'
-      @s.port.should == 2020
+      expect(@s.address).to eq('10.2.1.1')
+      expect(@s.port).to eq(2020)
     end
 
     it 'accepts a logger' do
       logger = double('logger')
       @s.logger = logger
-      @s.logger.should == logger
+      expect(@s.logger).to eq(logger)
     end
 
     it 'accepts an app' do
       app = double('app')
       @s.app = app
-      @s.app.should == app
+      expect(@s.app).to eq(app)
     end
 
     it 'accepts config' do
       config = double('config')
       @s.config = config
-      @s.config.should == config
+      expect(@s.config).to eq(config)
     end
   end
 
   describe 'startup' do
     before(:each) do
-      EM.should_receive(:synchrony).and_yield
+      expect(EM).to receive(:synchrony).and_yield
     end
 
     it 'starts' do
       addr = '10.2.1.1'
       port = 10000
 
-      EM.should_receive(:start_server).with(addr, port, anything)
+      expect(EM).to receive(:start_server).with(addr, port, anything)
 
       @s.address = addr
       @s.port = port
@@ -62,9 +62,9 @@ describe Goliath::Server do
       app = double('application')
 
       conn = double("connection").as_null_object
-      conn.should_receive(:app=).with(app)
+      expect(conn).to receive(:app=).with(app)
 
-      EM.should_receive(:start_server).and_yield(conn)
+      expect(EM).to receive(:start_server).and_yield(conn)
 
       @s.app = app
       @s.start
@@ -74,9 +74,9 @@ describe Goliath::Server do
       logger = double('logger')
 
       conn = double("connection").as_null_object
-      conn.should_receive(:logger=).with(logger)
+      expect(conn).to receive(:logger=).with(logger)
 
-      EM.should_receive(:start_server).and_yield(conn)
+      expect(EM).to receive(:start_server).and_yield(conn)
 
       @s.logger = logger
       @s.start
@@ -86,9 +86,9 @@ describe Goliath::Server do
       status = double('status')
 
       conn = double("connection").as_null_object
-      conn.should_receive(:status=).with(status)
+      expect(conn).to receive(:status=).with(status)
 
-      EM.should_receive(:start_server).and_yield(conn)
+      expect(EM).to receive(:start_server).and_yield(conn)
 
       @s.status = status
       @s.start
@@ -96,9 +96,9 @@ describe Goliath::Server do
 
     it 'loads the config for each connection' do
       conn = double("connection").as_null_object
-      EM.should_receive(:start_server).and_yield(conn)
+      expect(EM).to receive(:start_server).and_yield(conn)
 
-      @s.should_receive(:load_config)
+      expect(@s).to receive(:load_config)
       @s.start
     end
   end
@@ -113,28 +113,28 @@ describe Goliath::Server do
         Goliath.env = :development
         block_run = false
         @s.environment('development') { block_run = true }
-        block_run.should be_true
+        expect(block_run).to be_truthy
       end
 
       it 'does not execute the block if the environment does not match' do
         Goliath.env = :development
         block_run = false
         @s.environment('test') { block_run = true }
-        block_run.should be_false
+        expect(block_run).to be_falsey
       end
 
       it 'accepts an array of environments' do
         Goliath.env = :development
         block_run = false
         @s.environment(['development', 'test']) { block_run = true }
-        block_run.should be_true
+        expect(block_run).to be_truthy
       end
 
       it 'does not run the block if the environment is not in the array' do
         Goliath.env = :production
         block_run = false
         @s.environment(['development', 'test']) { block_run = true }
-        block_run.should be_false
+        expect(block_run).to be_falsey
       end
     end
   end

--- a/spec/unit/validation/standard_http_errors_spec.rb
+++ b/spec/unit/validation/standard_http_errors_spec.rb
@@ -3,19 +3,19 @@ require 'goliath/validation/standard_http_errors'
 
 describe Goliath::Validation::Error do
   it 'defines exceptions for each standard error response' do
-    lambda { Goliath::Validation::BadRequestError.new }.should_not raise_error
-    Goliath::Validation::BadRequestError.should < Goliath::Validation::Error
+    expect { Goliath::Validation::BadRequestError.new }.not_to raise_error
+    expect(Goliath::Validation::BadRequestError).to be < Goliath::Validation::Error
   end
 
   it 'defines InternalServerError not InternalServerErrorError' do
-    lambda { Goliath::Validation::InternalServerError.new }.should_not raise_error
-    Goliath::Validation::InternalServerError.should < Goliath::Validation::Error
+    expect { Goliath::Validation::InternalServerError.new }.not_to raise_error
+    expect(Goliath::Validation::InternalServerError).to be < Goliath::Validation::Error
   end
 
   it 'sets a default status code and message' do
     nfe = Goliath::Validation::NotFoundError.new
-    nfe.status_code.should == '404'
-    nfe.message.should == 'Not Found'
+    expect(nfe.status_code).to eq('404')
+    expect(nfe.message).to eq('Not Found')
   end
 end
 


### PR DESCRIPTION
**Depends on** #310 (touch me if I should separate this one, #310 includes some test fix)

Move to RSpec 3, update dependencies(`guard` [uses `cmd` option](https://github.com/guard/guard-rspec#options) now), fix deprecations. Transpec was used, https://relishapp.com/rspec/docs/upgrade

```json
Converting spec/integration/async_request_processing.rb
Converting spec/integration/chunked_streaming_spec.rb
Converting spec/integration/early_abort_spec.rb
Converting spec/integration/echo_spec.rb
Converting spec/integration/empty_body_spec.rb
Converting spec/integration/event_stream_spec.rb
Converting spec/integration/http_log_spec.rb
Converting spec/integration/jsonp_spec.rb
Converting spec/integration/keepalive_spec.rb
Converting spec/integration/pipelining_spec.rb
Converting spec/integration/reloader_spec.rb
Converting spec/integration/template_spec.rb
Converting spec/integration/test_helper_spec.rb
Converting spec/integration/trace_spec.rb
Converting spec/integration/valid_spec.rb
Converting spec/integration/websocket_spec.rb
Converting spec/spec_helper.rb
Converting spec/unit/api_spec.rb
Converting spec/unit/connection_spec.rb
Converting spec/unit/console_spec.rb
Converting spec/unit/env_spec.rb
Converting spec/unit/headers_spec.rb
Converting spec/unit/rack/default_mime_type_spec.rb
Converting spec/unit/rack/formatters/json_spec.rb
Converting spec/unit/rack/formatters/plist_spec.rb
Converting spec/unit/rack/formatters/xml_spec.rb
Converting spec/unit/rack/formatters/yaml_spec.rb
Converting spec/unit/rack/heartbeat_spec.rb
Converting spec/unit/rack/params_spec.rb
Converting spec/unit/rack/render_spec.rb
Converting spec/unit/rack/validation/boolean_value_spec.rb
Converting spec/unit/rack/validation/default_params_spec.rb
Converting spec/unit/rack/validation/numeric_range_spec.rb
Converting spec/unit/rack/validation/param_spec.rb
Converting spec/unit/rack/validation/request_method_spec.rb
Converting spec/unit/rack/validation/required_param_spec.rb
Converting spec/unit/rack/validation/required_value_spec.rb
Converting spec/unit/request_spec.rb
Converting spec/unit/response_spec.rb
Converting spec/unit/runner_spec.rb
Converting spec/unit/server_spec.rb
Converting spec/unit/validation/standard_http_errors_spec.rb

Summary:

317 conversions
  from: obj.should
    to: expect(obj).to
213 conversions
  from: == expected
    to: eq(expected)
62 conversions
  from: obj.should_receive(:message)
    to: expect(obj).to receive(:message)
36 conversions
  from: be_false
    to: be_falsey
29 conversions
  from: be_true
    to: be_truthy
26 conversions
  from: lambda { }.should_not
    to: expect { }.not_to
20 conversions
  from: =~ /pattern/
    to: match(/pattern/)
18 conversions
  from: obj.should_not
    to: expect(obj).not_to
14 conversions
  from: obj.stub(:message)
    to: allow(obj).to receive(:message)
11 conversions
  from: obj.should_not_receive(:message)
    to: expect(obj).not_to receive(:message)
9 conversions
  from: lambda { }.should
    to: expect { }.to
2 conversions
  from: < expected
    to: be < expected
1 conversion
  from: Klass.any_instance.should_receive(:message)
    to: expect_any_instance_of(Klass).to receive(:message)
1 conversion
  from: obj.should have(n).middlewares
    to: expect(obj.middlewares.size).to eq(n)

759 conversions, 0 incompletes, 0 warnings, 0 errors
```

Tests output:
```json
be rake
/home/dmitry/.rvm/rubies/ruby-2.2.1/bin/ruby -I/home/dmitry/.rvm/gems/ruby-2.2.1/gems/rspec-core-3.2.2/lib:/home/dmitry/.rvm/gems/ruby-2.2.1/gems/rspec-support-3.2.2/lib /home/dmitry/.rvm/gems/ruby-2.2.1/gems/rspec-core-3.2.2/exe/rspec --pattern spec/\*\*/\*_spec.rb
......................................................................................................................................................................................................................................................................................................................................................

Finished in 1.08 seconds (files took 1.91 seconds to load)
342 examples, 0 failures

/home/dmitry/.rvm/rubies/ruby-2.2.1/bin/ruby -I"lib:test"  "/home/dmitry/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/rake/rake_test_loader.rb" "test/echo_test.rb" 
Loaded suite /home/dmitry/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/rake/rake_test_loader
Started
.

Finished in 0.01041581 seconds.
------------------------------------------------------------------------------------------------------
1 tests, 1 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
------------------------------------------------------------------------------------------------------
96.01 tests/s, 96.01 assertions/s
```