### PR TITLE
Conform to the `QUERY_STRING` Rack requirements (not `nil`)

### DIFF
--- a/lib/goliath/request.rb
+++ b/lib/goliath/request.rb
@@ -92,7 +92,7 @@ module Goliath
 
         @env[REQUEST_METHOD]  = parser.http_method
         @env[REQUEST_URI]     = parser.request_url
-        @env[QUERY_STRING]    = uri.query
+        @env[QUERY_STRING]    = uri.query || ''.freeze
         @env[HTTP_VERSION]    = parser.http_version.join('.')
         @env[SCRIPT_NAME]     = ""
         @env[REQUEST_PATH]    = uri.path


### PR DESCRIPTION
According to [the Rack specs](http://www.rubydoc.info/github/rack/rack/file/SPEC), `QUERY_STRING` must be present, even if empty.

> The portion of the request URL that follows the ?, if any. May be empty, **but is always required!**

The URI parser will return `nil` for a missing `QUERY_STRING`, which results in non-conformity with the Rack standard.

By making sure this is a string, this issue would be resolved.