### PR TITLE
Add https? to logger so terminals can recognize URL

### DIFF
--- a/lib/goliath/runner.rb
+++ b/lib/goliath/runner.rb
@@ -298,8 +298,7 @@ module Goliath
      # @return [Nil]
      def run_server
        log = setup_logger
-
-       log.info("Starting server on #{@address}:#{@port} in #{Goliath.env} mode. Watch out for stones.")
+       log.info("Starting server on http#{ @server_options[:ssl] ? 's' : nil }://#{@address}:#{@port} in #{Goliath.env} mode. Watch out for stones.")
 
        server = setup_server(log)
        server.api.setup if server.api.respond_to?(:setup)


### PR DESCRIPTION
With recognized URL you can easily open the server in default browser.
Not entirely sure if I got the SSL-part right though.