### PR TITLE
Allow specifying response headers for errors

### DIFF
--- a/lib/goliath/api.rb
+++ b/lib/goliath/api.rb
@@ -172,7 +172,7 @@ module Goliath
 
       rescue Goliath::Validation::Error => e
         env[RACK_EXCEPTION] = e
-        env[ASYNC_CALLBACK].call(validation_error(e.status_code, e.message))
+        env[ASYNC_CALLBACK].call(validation_error(e.status_code, e.message, e.headers))
 
       rescue Exception => e
         logthis = "#{e.backtrace[0]}: #{e.message} (#{e.class})\n"

--- a/lib/goliath/rack/validator.rb
+++ b/lib/goliath/rack/validator.rb
@@ -39,7 +39,7 @@ module Goliath
         begin
           yield
         rescue Goliath::Validation::Error => e
-          validation_error(e.status_code, e.message, headers)
+          validation_error(e.status_code, e.message, e.headers.merge(headers))
         rescue Exception => e
           env.logger.error(e.message)
           env.logger.error(e.backtrace.join("\n"))

--- a/lib/goliath/request.rb
+++ b/lib/goliath/request.rb
@@ -226,7 +226,7 @@ module Goliath
     # @return [Nil]
     def server_exception(e)
       if e.is_a?(Goliath::Validation::Error)
-        status, headers, body = [e.status_code, {}, ('{"error":"%s"}' % e.message)]
+        status, headers, body = [e.status_code, e.headers, ('{"error":"%s"}' % e.message)]
       else
         @env[RACK_LOGGER].error("#{e.message}\n#{e.backtrace.join("\n")}")
         message = Goliath.env?(:production) ? 'An error happened' : e.message

--- a/lib/goliath/validation/error.rb
+++ b/lib/goliath/validation/error.rb
@@ -4,6 +4,8 @@ module Goliath
     class Error < StandardError
       # The status code to return from the error handler
       attr_accessor :status_code
+      # The headers to return from the error handler
+      attr_accessor :headers
 
       # Create a new Goliath::Validation::Error.
       #
@@ -13,9 +15,10 @@ module Goliath
       # @param status_code [Integer] The status code to return
       # @param message [String] The error message to return
       # @return [Goliath::Validation::Error] The Goliath::Validation::Error
-      def initialize(status_code, message)
+      def initialize(status_code, message, headers = {})
         super(message)
         @status_code = status_code
+        @headers = headers
       end
     end
   end

--- a/spec/integration/valid_spec.rb
+++ b/spec/integration/valid_spec.rb
@@ -54,7 +54,7 @@ end
 
 class ValidationErrorInEndpoint < Goliath::API
   def response(env)
-    raise Goliath::Validation::Error.new(420, 'You Must Chill')
+    raise Goliath::Validation::Error.new(420, 'You Must Chill', {'Foo' => 'Bar'})
   end
 end
 
@@ -66,8 +66,28 @@ describe ValidationErrorInEndpoint do
       get_request({}, err) do |c|
         c.response.should == '[:error, "You Must Chill"]'
         c.response_header.status.should == 420
+        c.response_header["Foo"].should == 'Bar'
       end
     end
   end
 end
 
+class ValidationErrorWhileParsing < Goliath::API
+  def on_headers(env, headers)
+    raise Goliath::Validation::Error.new(420, 'You Must Chill', {'Foo' => 'Bar'})
+  end
+end
+
+describe ValidationErrorWhileParsing do
+  let(:err) { Proc.new { fail "API request failed" } }
+
+  it 'handles Goliath::Validation::Error correctly' do
+    with_api(ValidationErrorInEndpoint) do
+      get_request({}, err) do |c|
+        c.response.should == '[:error, "You Must Chill"]'
+        c.response_header.status.should == 420
+        c.response_header["Foo"].should == 'Bar'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently there is no way to specify response headers when raising a validation error. This change allows you to raise a validation errors with optional headers in `#response`, but also while parsing in `#on_headers` and `#on_body`.

```rb
raise Goliath::Validation::Error.new(412, "Error occurred", {"Foo" => "Bar"})
```

I needed this when implementing [TUS](http://tus.io/); if a request is invalid I need to return the `Tus-Version` header. I could avoid raising `Goliath::Validation::Error` and just handle everything in `#response`, but I wanted to avoid receiving the body if I already determined an error in headers.