### PR TITLE
Update rspec and its dependencies to ~> 3.0

### DIFF
--- a/goliath.gemspec
+++ b/goliath.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'multi_json'
 
   s.add_development_dependency 'rake', '>=0.8.7'
-  s.add_development_dependency 'rspec', '>2.0'
+  s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'test-unit'
   s.add_development_dependency 'nokogiri'
   s.add_development_dependency 'em-http-request', '>=1.0.0'
@@ -43,9 +43,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'haml', '>=3.0.25'
   s.add_development_dependency 'yard'
 
-  s.add_development_dependency 'guard', '~> 1.8.3'
-  s.add_development_dependency 'guard-rspec', '~> 3.1.0'
-  s.add_development_dependency 'listen', '~> 1.3.1'
+  s.add_development_dependency 'guard', '~> 2.0'
+  s.add_development_dependency 'guard-rspec', '~> 4.0'
+  s.add_development_dependency 'listen', '~> 2.0'
 
   if RUBY_PLATFORM != 'java'
     s.add_development_dependency 'yajl-ruby'

--- a/spec/unit/api_spec.rb
+++ b/spec/unit/api_spec.rb
@@ -7,7 +7,7 @@ describe Goliath::API do
 
   describe "middlewares" do
     it "doesn't change after multi calls" do
-      2.times { DummyApi.should have(2).middlewares }
+      2.times { DummyApi.middlewares.size.should eq(2) }
     end
   end
 end

--- a/spec/unit/rack/params_spec.rb
+++ b/spec/unit/rack/params_spec.rb
@@ -115,10 +115,7 @@ Berry\r
     end
 
     it 'sets the params into the environment' do
-      @app.should_receive(:call).with do |app_env|
-        app_env.has_key?('params').should be true
-        app_env['params']['a'].should == 'b'
-      end
+      @app.should receive(:call).with(hash_including("params"=>{"a"=>"b"}))
 
       @env['QUERY_STRING'] = "a=b"
       @params.call(@env)


### PR DESCRIPTION
There are still many warnings, but at least the tests pass.