### PR TITLE
Add description to 'raise_error' spec matcher

### DIFF
--- a/spec/unit/rack/validation/default_params_spec.rb
+++ b/spec/unit/rack/validation/default_params_spec.rb
@@ -8,11 +8,11 @@ describe Goliath::Rack::Validation::DefaultParams do
   end
 
   it 'requires defaults to be set' do
-    lambda { Goliath::Rack::Validation::DefaultParams.new('my app', {:key => 'test'}) }.should raise_error
+    lambda { Goliath::Rack::Validation::DefaultParams.new('my app', {:key => 'test'}) }.should raise_error('Must provide defaults to DefaultParams')
   end
 
   it 'requires key to be set' do
-    lambda { Goliath::Rack::Validation::DefaultParams.new('my app', {:defaults => 'test'}) }.should raise_error
+    lambda { Goliath::Rack::Validation::DefaultParams.new('my app', {:defaults => 'test'}) }.should raise_error('must provide key to DefaultParams')
   end
 
   describe 'with middleware' do

--- a/spec/unit/rack/validation/numeric_range_spec.rb
+++ b/spec/unit/rack/validation/numeric_range_spec.rb
@@ -66,11 +66,11 @@ describe Goliath::Rack::Validation::NumericRange do
   end
 
   it 'raises error if key is not set' do
-    lambda { Goliath::Rack::Validation::NumericRange.new('app', {:min => 5}) }.should raise_error
+    lambda { Goliath::Rack::Validation::NumericRange.new('app', {:min => 5}) }.should raise_error('NumericRange key required')
   end
 
   it 'raises error if neither min nor max set' do
-    lambda { Goliath::Rack::Validation::NumericRange.new('app', {:key => 5}) }.should raise_error
+    lambda { Goliath::Rack::Validation::NumericRange.new('app', {:key => 5}) }.should raise_error('NumericRange requires :min or :max')
   end
 
   it 'uses min if default not set' do

--- a/spec/unit/rack/validation/param_spec.rb
+++ b/spec/unit/rack/validation/param_spec.rb
@@ -10,7 +10,7 @@ describe Goliath::Rack::Validation::Param do
   it "should not allow invalid options" do
     lambda {
       Goliath::Rack::Validation::Param.new(@app, {:key => 'user', :as => Class.new})
-    }.should raise_error
+    }.should raise_error(Exception)
   end
 
   it "raises if key is not supplied" do
@@ -40,7 +40,7 @@ describe Goliath::Rack::Validation::Param do
     lambda {
       cv = Goliath::Rack::Validation::Param.new(@app, {:key => 'flag',
           :as => Goliath::Rack::Types::Boolean, :animal => :monkey})
-    }.should raise_error
+    }.should raise_error('Unknown options: {:animal=>:monkey}')
   end
 
   context "fetch_key" do
@@ -247,7 +247,7 @@ describe Goliath::Rack::Validation::Param do
     it "should only accept a class in the :as" do
       lambda {
         Goliath::Rack::Validation::Param.new(@app, {:key => 'user', :as => "not a class"})
-      }.should raise_error
+      }.should raise_error('Params as must be a class')
     end
 
     context 'with middleware' do


### PR DESCRIPTION
This removes the messages "WARNING: Using the `raise_error` matcher without
providing a specific error or message ..." when running specs.