### PR TITLE
Remove rspec deprecation warning about :example_group

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,5 @@ require 'goliath/test_helper'
 Goliath.env = :test
 
 RSpec.configure do |c|
-  c.include Goliath::TestHelper, :example_group => {
-    :file_path => /spec\/integration/
-  }
+  c.include Goliath::TestHelper, :file_path => /spec\/integration/
 end


### PR DESCRIPTION
Rspec deprecated ':example_group' subhash and it is not needed anymore.
If used, it complains with the following message: "Filtering by an
`:example_group` subhash is deprecated. Use the subhash to filter
directly instead."