### PR TITLE
Add json:api support to the JSON formatter

### DIFF
--- a/lib/goliath/rack/formatters/json.rb
+++ b/lib/goliath/rack/formatters/json.rb
@@ -19,7 +19,7 @@ module Goliath
         end
 
         def json_response?(headers)
-          headers['Content-Type'] =~ %r{^application/(json|javascript|vnd\.api\+json)}
+          headers['Content-Type'] =~ %r{^application/((vnd\.api\+)?json|javascript|javascript)}
         end
       end
     end

--- a/lib/goliath/rack/formatters/json.rb
+++ b/lib/goliath/rack/formatters/json.rb
@@ -19,7 +19,7 @@ module Goliath
         end
 
         def json_response?(headers)
-          headers['Content-Type'] =~ %r{^application/(json|javascript)}
+          headers['Content-Type'] =~ %r{^application/(json|javascript|vnd\.api\+json)}
         end
       end
     end

--- a/lib/goliath/rack/formatters/json.rb
+++ b/lib/goliath/rack/formatters/json.rb
@@ -19,7 +19,7 @@ module Goliath
         end
 
         def json_response?(headers)
-          headers['Content-Type'] =~ %r{^application/((vnd\.api\+)?json|javascript|javascript)}
+          headers['Content-Type'] =~ %r{^application/((vnd\.api\+)?json|javascript)}
         end
       end
     end

--- a/spec/unit/rack/formatters/json_spec.rb
+++ b/spec/unit/rack/formatters/json_spec.rb
@@ -16,6 +16,14 @@ describe Goliath::Rack::Formatters::JSON do
       expect(@js.json_response?({'Content-Type' => 'application/json'})).to be_truthy
     end
 
+    it 'checks content type for application/vnd.api+json' do
+      expect(@js.json_response?({'Content-Type' => 'application/vnd.api+json'})).to be_truthy
+    end
+
+    it 'checks content type for application/javascript' do
+      expect(@js.json_response?({'Content-Type' => 'application/javascript'})).to be_truthy
+    end
+
     it 'returns false for non-applicaton/json types' do
       expect(@js.json_response?({'Content-Type' => 'application/xml'})).to be_falsey
     end
@@ -28,6 +36,20 @@ describe Goliath::Rack::Formatters::JSON do
 
     it 'formats the body into json if content-type is json' do
       expect(@app).to receive(:call).and_return([200, {'Content-Type' => 'application/json'}, {:a => 1, :b => 2}])
+
+      status, header, body = @js.call({})
+      expect { expect(MultiJson.load(body.first)['a']).to eq(1) }.not_to raise_error
+    end
+
+    it 'formats the body into json if content-type is vnd.api+json' do
+      expect(@app).to receive(:call).and_return([200, {'Content-Type' => 'application/vnd.api+json'}, {:a => 1, :b => 2}])
+
+      status, header, body = @js.call({})
+      expect { expect(MultiJson.load(body.first)['a']).to eq(1) }.not_to raise_error
+    end
+
+    it 'formats the body into json if content-type is javascript' do
+      expect(@app).to receive(:call).and_return([200, {'Content-Type' => 'application/javascript'}, {:a => 1, :b => 2}])
 
       status, header, body = @js.call({})
       expect { expect(MultiJson.load(body.first)['a']).to eq(1) }.not_to raise_error


### PR DESCRIPTION
The json:api (http://jsonapi.org/) spec requires a content-type of
`application/vnd.api+json`, which was not matched by the JSON formatter.
This new content-type has been added to the formatter with respective
tests, and I also added a few missing tests cases to the formatter spec.

Resolves #334 