### PR TITLE
Stream the response to the client

### DIFF
--- a/goliath.gemspec
+++ b/goliath.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'amqp', '>=0.7.1'
   s.add_development_dependency 'em-websocket-client'
   s.add_development_dependency 'em-eventsource'
+  s.add_development_dependency 'rack', '< 2'
 
   s.add_development_dependency 'tilt', '>=1.2.2'
   s.add_development_dependency 'haml', '>=3.0.25'

--- a/lib/goliath/connection.rb
+++ b/lib/goliath/connection.rb
@@ -41,7 +41,8 @@ module Goliath
       end
 
       @parser.on_body = proc do |data|
-        @requests.first.parse(data)
+        req = @requests.first
+        req.parse(data) unless req.env[:terminate_connection]
       end
 
       @parser.on_message_complete = proc do

--- a/lib/goliath/connection.rb
+++ b/lib/goliath/connection.rb
@@ -84,15 +84,17 @@ module Goliath
     end
 
     def terminate_request(keep_alive)
-      if req = @pending.shift
-        @current = req
-        @current.succeed
-      elsif @current
+      if @current
         @current.close
         @current = nil
       end
 
       close_connection_after_writing rescue nil if !keep_alive
+
+      if req = @pending.shift
+        @current = req
+        @current.succeed
+      end
     end
 
     def remote_address

--- a/lib/goliath/rack/default_response_format.rb
+++ b/lib/goliath/rack/default_response_format.rb
@@ -4,17 +4,11 @@ module Goliath
       include Goliath::Rack::AsyncMiddleware
 
       def post_process(env, status, headers, body)
-        return [status, headers, body] if body.respond_to?(:to_ary)
-
-        new_body = []
-        if body.respond_to?(:each)
-          body.each { |chunk| new_body << chunk }
+        if body.is_a?(String)
+          [status, headers, [body]]
         else
-          new_body << body
+          [status, headers, body]
         end
-        new_body.collect! { |item| item.to_s }
-
-        [status, headers, new_body.flatten]
       end
     end
   end

--- a/lib/goliath/request.rb
+++ b/lib/goliath/request.rb
@@ -237,11 +237,6 @@ module Goliath
       headers['Content-Length'] = body.bytesize.to_s
       @env[:terminate_connection] = true
       post_process([status, headers, body])
-
-      # Mark the request as complete to force a flush on the response.
-      # Note: #on_body and #response hooks may still fire if the data
-      # is already in the parser buffer.
-      succeed
     end
 
     # Used to determine if the connection should  be kept open

--- a/lib/goliath/response.rb
+++ b/lib/goliath/response.rb
@@ -79,6 +79,8 @@ module Goliath
     # @yield [String] The header line, headers and body content
     # @return [Nil]
     def each
+      return enum_for(__method__) unless block_given?
+
       yield head
       yield headers_output
 


### PR DESCRIPTION
Currently if you give the Goliath an array response body, it will not stream the response to the client, but instead it will send all data at once. This is unlike most other popular Ruby web servers, which write response data to the TCP socket during iteration. See https://github.com/postrank-labs/goliath/issues/339 for the initial struggles.

This is because it loops over the whole response and calls `EM::Connection#send_data` for each chunk all inside a _single EM tick_, and [as per EventMachine documentation](https://github.com/eventmachine/eventmachine/blob/a439d72aad1006003ed59f72360e03b5dde25c2f/lib/em/connection.rb#L307), EventMachine will buffer all that data and actually write it to the TCP socket at the end of the tick.

This pull request modifies `Goliath::Request#post_process` to send each chunk of the response body in a new tick. This should also work well if the response body is generated dynamically, e.g. a streaming S3 object, or CSV that is generated on-the-fly.