### PR TITLE
Log full exception in Goliath::Request#server_exception

### DIFF
--- a/lib/goliath/request.rb
+++ b/lib/goliath/request.rb
@@ -228,9 +228,14 @@ module Goliath
       if e.is_a?(Goliath::Validation::Error)
         status, headers, body = [e.status_code, e.headers, ('{"error":"%s"}' % e.message)]
       else
-        @env[RACK_LOGGER].error("#{e.message}\n#{e.backtrace.join("\n")}")
-        message = Goliath.env?(:production) ? 'An error happened' : e.message
+        logthis = "#{e.backtrace[0]}: #{e.message} (#{e.class})\n"
+        e.backtrace[1..-1].each do |bt|
+          logthis += "    from #{bt}\n"
+        end
+        @env.logger.error(logthis)
+        @env[RACK_EXCEPTION] = e
 
+        message = Goliath.env?(:production) ? 'An error happened' : e.message
         status, headers, body = [500, {}, message]
       end
 


### PR DESCRIPTION
The exeption that `Goliath::Request#server_exception` logs isn't complete, because it's missing the exception class. 

```
divided by 0
app.rb:5:in `/'
app.rb:5:in `on_headers'
/Users/janko/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/goliath-1.0.5/lib/goliath/request.rb:104:in `call'
/Users/janko/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/goliath-1.0.5/lib/goliath/request.rb:104:in `parse_header'
/Users/janko/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/goliath-1.0.5/lib/goliath/connection.rb:34:in `block in post_init'
/Users/janko/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/goliath-1.0.5/lib/goliath/connection.rb:63:in `<<'
/Users/janko/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/goliath-1.0.5/lib/goliath/connection.rb:63:in `receive_data'
/Users/janko/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/eventmachine-1.2.5/lib/eventmachine.rb:194:in `run_machine'
/Users/janko/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/eventmachine-1.2.5/lib/eventmachine.rb:194:in `run'
/Users/janko/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/em-synchrony-1.0.6/lib/em-synchrony.rb:39:in `synchrony'
/Users/janko/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/goliath-1.0.5/lib/goliath/server.rb:74:in `start'
/Users/janko/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/goliath-1.0.5/lib/goliath/runner.rb:305:in `run_server'
/Users/janko/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/goliath-1.0.5/lib/goliath/runner.rb:226:in `run'
/Users/janko/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/goliath-1.0.5/lib/goliath/application.rb:111:in `run!'
/Users/janko/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/goliath-1.0.5/lib/goliath/application.rb:133:in `block in <module:Goliath>'
```

So I just copied the same implementation that `Goliath::API#call` already has for logging exceptions, which mimics the way that Ruby would log it.

```
app.rb:5:in `/': divided by 0 (ZeroDivisionError)
    from app.rb:5:in `on_headers'
    from /Users/janko/Code/clones/goliath/lib/goliath/request.rb:104:in `call'
    from /Users/janko/Code/clones/goliath/lib/goliath/request.rb:104:in `parse_header'
    from /Users/janko/Code/clones/goliath/lib/goliath/connection.rb:34:in `block in post_init'
    from /Users/janko/Code/clones/goliath/lib/goliath/connection.rb:63:in `<<'
    from /Users/janko/Code/clones/goliath/lib/goliath/connection.rb:63:in `receive_data'
    from /Users/janko/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/eventmachine-1.0.9.1/lib/eventmachine.rb:193:in `run_machine'
    from /Users/janko/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/eventmachine-1.0.9.1/lib/eventmachine.rb:193:in `run'
    from /Users/janko/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/em-synchrony-1.0.6/lib/em-synchrony.rb:39:in `synchrony'
    from /Users/janko/Code/clones/goliath/lib/goliath/server.rb:74:in `start'
    from /Users/janko/Code/clones/goliath/lib/goliath/runner.rb:305:in `run_server'
    from /Users/janko/Code/clones/goliath/lib/goliath/runner.rb:226:in `run'
    from /Users/janko/Code/clones/goliath/lib/goliath/application.rb:111:in `run!'
    from /Users/janko/Code/clones/goliath/lib/goliath/application.rb:133:in `block in <module:Goliath>'
```

This makes logging exceptions consistent regardless of whether the exceptions happens in `#on_headers`/`#on_body` or `#response`.