### PR TITLE
Avoid warning due to 'headers=' being redefined

### DIFF
--- a/lib/goliath/response.rb
+++ b/lib/goliath/response.rb
@@ -13,7 +13,7 @@ module Goliath
     attr_accessor :status
 
     # The headers to send
-    attr_accessor :headers
+    attr_reader :headers
 
     # The body to send
     attr_accessor :body


### PR DESCRIPTION
Do not use 'attr_accessor' with @headers variable, use 'attr_reader'
instead. Otherwise, there is warning for 'headers=' method being
refined, as there is already a method for setting the @headers variable.