### PR TITLE
Avoid warning for assigned variable not being used

### DIFF
--- a/lib/goliath/connection.rb
+++ b/lib/goliath/connection.rb
@@ -73,7 +73,7 @@ module Goliath
           end
         end
 
-      rescue HTTP::Parser::Error => e
+      rescue HTTP::Parser::Error
         terminate_request(false)
       end
     end


### PR DESCRIPTION
Do not assign variable if it will not be used. This avoids a "warning:
assigned but unused variable - e" message.