### PR TITLE
Stop sending response data if connection is closed

### DIFF
--- a/lib/goliath/request.rb
+++ b/lib/goliath/request.rb
@@ -214,8 +214,9 @@ module Goliath
 
     # Writes each chunk of the response data in a new tick. This achieves
     # streaming, because EventMachine flushes the sent data to the socket at
-    # the end of each tick.
+    # the end of each tick. Stops sending data if connection has been closed.
     def stream_data(chunks, &block)
+      return if @response.closed?
       @conn.send_data(chunks.next)
       EM.next_tick { stream_data(chunks, &block) }
     rescue StopIteration

--- a/lib/goliath/response.rb
+++ b/lib/goliath/response.rb
@@ -28,6 +28,7 @@ module Goliath
     def initialize
       @headers = Goliath::Headers.new
       @status = 200
+      @closed = false
     end
 
     # Creates the header line for the response
@@ -72,6 +73,14 @@ module Goliath
     # @return [Nil]
     def close
       body.close if body.respond_to?(:close)
+      @closed = true
+    end
+
+    # Returns whether the response has been closed
+    #
+    # @return [Boolean]
+    def closed?
+      @closed
     end
 
     # Yields each portion of the response


### PR DESCRIPTION
If the connection has been closed, there is no point in continuing iterating over the response body and continuing to send data, because it will never get written to the socket anyway. This saves on performance.

Also, once `#close` has been called on the response body, continuing to iterate over it might raise an exception. Imagine a scenario where the body is a lazy enumerable that retrieves chunks from an open file, and `#close` closes the file.