### PR TITLE
Fix File.exists? warning on Ruby 3

### DIFF
--- a/examples/rasterize/rasterize.rb
+++ b/examples/rasterize/rasterize.rb
@@ -17,7 +17,7 @@ class Rasterize < Goliath::API
     url = PostRank::URI.clean(params['url'])
     hash = PostRank::URI.hash(url, :clean => false)
 
-    if !File.exists? filename(hash)
+    if !File.exist? filename(hash)
       fiber = Fiber.current
       EM.system('phantomjs rasterize.js ' + url.to_s + ' ' + filename(hash)) do |output, status|
         env.logger.info "Phantom exit status: #{status}"

--- a/lib/goliath/rack/templates.rb
+++ b/lib/goliath/rack/templates.rb
@@ -251,7 +251,7 @@ module Goliath
       # @return [String | nil] Template file or nil if it doesn't exist.
       def find_template(views, name, engine)
         filename = ::File.join(views, "#{name}.#{engine}")
-        File.exists?(filename) ? filename : nil
+        File.exist?(filename) ? filename : nil
       end
 
       # Renders a template with the given engine. Don't call this directly --

--- a/lib/goliath/server.rb
+++ b/lib/goliath/server.rb
@@ -132,7 +132,7 @@ module Goliath
     def load_config(file = nil)
       api_name = api.class.to_s.gsub('::', '_').gsub(/([^_A-Z])([A-Z])/,'\1_\2').downcase!
       file ||= "#{config_dir}/#{api_name}.rb"
-      return unless File.exists?(file)
+      return unless File.exist?(file)
 
       proc = Proc.new {} # create proc to grab binding
       eval(IO.read(file), proc.binding, file)


### PR DESCRIPTION
This fixes warnings regarding the use of `File.exists?` method on Ruby 3:

    warning: File.exists? is deprecated; use File.exist? instead